### PR TITLE
Tax Jurisdiction Names

### DIFF
--- a/src/main/java/com/taxjar/model/taxes/Jurisdictions.java
+++ b/src/main/java/com/taxjar/model/taxes/Jurisdictions.java
@@ -1,0 +1,25 @@
+package com.taxjar.model.taxes;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Jurisdictions {
+    @SerializedName("country")
+    String country;
+
+    @SerializedName("state")
+    String state;
+
+    @SerializedName("county")
+    String county;
+
+    @SerializedName("city")
+    String city;
+
+    public String getCountry() { return country; }
+
+    public String getState() { return state; }
+
+    public String getCounty() { return county; }
+
+    public String getCity() { return city; }
+}

--- a/src/main/java/com/taxjar/model/taxes/Tax.java
+++ b/src/main/java/com/taxjar/model/taxes/Tax.java
@@ -29,6 +29,9 @@ public class Tax {
 
     // ---
 
+    @SerializedName("jurisdictions")
+    Jurisdictions jurisdictions;
+
     @SerializedName("breakdown")
     Breakdown breakdown;
 
@@ -63,6 +66,8 @@ public class Tax {
     public String getTaxSource() {
         return taxSource;
     }
+
+    public Jurisdictions getJurisdictions() { return jurisdictions; }
 
     public Breakdown getBreakdown() {
         return breakdown;

--- a/src/test/java/com/taxjar/functional/TaxTest.java
+++ b/src/test/java/com/taxjar/functional/TaxTest.java
@@ -62,6 +62,10 @@ public class TaxTest extends TestCase {
         assertEquals((Boolean) true, res.tax.getHasNexus());
         assertEquals((Boolean) true, res.tax.getFreightTaxable());
         assertEquals("destination", res.tax.getTaxSource());
+        assertEquals("US", res.tax.getJurisdictions().getCountry());
+        assertEquals("CA", res.tax.getJurisdictions().getState());
+        assertEquals("LOS ANGELES", res.tax.getJurisdictions().getCounty());
+        assertEquals("LOS ANGELES", res.tax.getJurisdictions().getCity());
         assertEquals(16.5f, res.tax.getBreakdown().getTaxableAmount());
         assertEquals(1.16f, res.tax.getBreakdown().getTaxCollectable());
         assertEquals(0.07f, res.tax.getBreakdown().getCombinedTaxRate());
@@ -124,6 +128,10 @@ public class TaxTest extends TestCase {
                 assertEquals((Boolean) true, res.tax.getHasNexus());
                 assertEquals((Boolean) true, res.tax.getFreightTaxable());
                 assertEquals("destination", res.tax.getTaxSource());
+                assertEquals("US", res.tax.getJurisdictions().getCountry());
+                assertEquals("CA", res.tax.getJurisdictions().getState());
+                assertEquals("LOS ANGELES", res.tax.getJurisdictions().getCounty());
+                assertEquals("LOS ANGELES", res.tax.getJurisdictions().getCity());
                 assertEquals(16.5f, res.tax.getBreakdown().getTaxableAmount());
                 assertEquals(1.16f, res.tax.getBreakdown().getTaxCollectable());
                 assertEquals(0.07f, res.tax.getBreakdown().getCombinedTaxRate());
@@ -189,6 +197,8 @@ public class TaxTest extends TestCase {
         assertEquals((Boolean) true, res.tax.getHasNexus());
         assertEquals((Boolean) true, res.tax.getFreightTaxable());
         assertEquals("destination", res.tax.getTaxSource());
+        assertEquals("CA", res.tax.getJurisdictions().getCountry());
+        assertEquals("ON", res.tax.getJurisdictions().getState());
         assertEquals(26.95f, res.tax.getBreakdown().getTaxableAmount());
         assertEquals(3.5f, res.tax.getBreakdown().getTaxCollectable());
         assertEquals(0.13f, res.tax.getBreakdown().getCombinedTaxRate());
@@ -230,6 +240,7 @@ public class TaxTest extends TestCase {
         assertEquals((Boolean) true, res.tax.getHasNexus());
         assertEquals((Boolean) true, res.tax.getFreightTaxable());
         assertEquals("destination", res.tax.getTaxSource());
+        assertEquals("FI", res.tax.getJurisdictions().getCountry());
         assertEquals(26.95f, res.tax.getBreakdown().getTaxableAmount());
         assertEquals(6.47f, res.tax.getBreakdown().getTaxCollectable());
         assertEquals(0.24f, res.tax.getBreakdown().getCombinedTaxRate());

--- a/src/test/resources/com/taxjar/fixtures/taxes.json
+++ b/src/test/resources/com/taxjar/fixtures/taxes.json
@@ -8,6 +8,12 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "US",
+      "state": "CA",
+      "county": "LOS ANGELES",
+      "city": "LOS ANGELES"
+    },
     "breakdown": {
       "taxable_amount": 16.5,
       "tax_collectable": 1.16,

--- a/src/test/resources/com/taxjar/fixtures/taxes_ca.json
+++ b/src/test/resources/com/taxjar/fixtures/taxes_ca.json
@@ -8,6 +8,10 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "CA",
+      "state": "ON"
+    },
     "breakdown": {
       "taxable_amount": 26.95,
       "tax_collectable": 3.5,

--- a/src/test/resources/com/taxjar/fixtures/taxes_eu.json
+++ b/src/test/resources/com/taxjar/fixtures/taxes_eu.json
@@ -8,6 +8,9 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "FI"
+    },
     "breakdown": {
       "taxable_amount": 26.95,
       "tax_collectable": 6.47,


### PR DESCRIPTION
This PR provides access to the new `jurisdictions` object in the /v2/taxes response.