### PR TITLE
Address Validation

### DIFF
--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -14,6 +14,7 @@ import com.taxjar.model.transactions.OrderResponse;
 import com.taxjar.model.transactions.OrdersResponse;
 import com.taxjar.model.transactions.RefundResponse;
 import com.taxjar.model.transactions.RefundsResponse;
+import com.taxjar.model.validations.AddressResponse;
 import com.taxjar.model.validations.ValidationResponse;
 import com.taxjar.net.Endpoints;
 import com.taxjar.net.Listener;
@@ -1107,6 +1108,48 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RegionResponse> call, Throwable t) {
+                t.printStackTrace();
+            }
+        });
+    }
+
+    public AddressResponse validateAddress(Map<String, Object> params) throws TaxjarException {
+        Call<AddressResponse> call = apiService.getAddresses(params);
+
+        try {
+            Response<AddressResponse> response = call.execute();
+            if (response.isSuccessful()) {
+                return response.body();
+            } else {
+                throw new TaxjarException(response.errorBody().string());
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    public void validateAddress(Map<String, Object> params, final Listener<AddressResponse> listener) {
+        Call<AddressResponse> call = apiService.getAddresses(params);
+
+        call.enqueue(new Callback<AddressResponse>() {
+            @Override
+            public void onResponse(Call<AddressResponse> call, Response<AddressResponse> response) {
+                if (response.isSuccessful()) {
+                    listener.onSuccess(response.body());
+                } else {
+                    try {
+                        TaxjarException exception = new TaxjarException(response.errorBody().string());
+                        listener.onError(exception);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Call<AddressResponse> call, Throwable t) {
                 t.printStackTrace();
             }
         });

--- a/src/main/java/com/taxjar/model/validations/Address.java
+++ b/src/main/java/com/taxjar/model/validations/Address.java
@@ -1,0 +1,40 @@
+package com.taxjar.model.validations;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Address {
+    @SerializedName("country")
+    String country;
+
+    @SerializedName("zip")
+    String zip;
+
+    @SerializedName("state")
+    String state;
+
+    @SerializedName("city")
+    String city;
+
+    @SerializedName("street")
+    String street;
+
+    public String getCountry() {
+        return country;
+    }
+
+    public String getZip() {
+        return zip;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+}

--- a/src/main/java/com/taxjar/model/validations/AddressResponse.java
+++ b/src/main/java/com/taxjar/model/validations/AddressResponse.java
@@ -1,0 +1,7 @@
+package com.taxjar.model.validations;
+
+import java.util.List;
+
+public class AddressResponse {
+    public List<Address> addresses;
+}

--- a/src/main/java/com/taxjar/net/Endpoints.java
+++ b/src/main/java/com/taxjar/net/Endpoints.java
@@ -11,6 +11,7 @@ import com.taxjar.model.transactions.OrderResponse;
 import com.taxjar.model.transactions.OrdersResponse;
 import com.taxjar.model.transactions.RefundResponse;
 import com.taxjar.model.transactions.RefundsResponse;
+import com.taxjar.model.validations.AddressResponse;
 import com.taxjar.model.validations.ValidationResponse;
 
 import retrofit2.Call;
@@ -88,6 +89,9 @@ public interface Endpoints
 
     @GET("nexus/regions")
     Call<RegionResponse> getRegions();
+
+    @POST("addresses/validate")
+    Call<AddressResponse> getAddresses(@Body Map<String, Object> params);
 
     @GET("validation")
     Call<ValidationResponse> getValidation(@QueryMap Map<String, String> params);

--- a/src/test/java/com/taxjar/functional/ValidationTest.java
+++ b/src/test/java/com/taxjar/functional/ValidationTest.java
@@ -3,6 +3,7 @@ package com.taxjar.functional;
 import com.taxjar.MockInterceptor;
 import com.taxjar.TaxjarMock;
 import com.taxjar.exception.TaxjarException;
+import com.taxjar.model.validations.AddressResponse;
 import com.taxjar.model.validations.ValidationResponse;
 import com.taxjar.net.Listener;
 import junit.framework.TestCase;
@@ -13,12 +14,111 @@ import java.util.Map;
 public class ValidationTest extends TestCase {
     private TaxjarMock client;
 
-    protected void setUp() {
-        MockInterceptor interceptor = new MockInterceptor("validation.json");
+    public void testValidateAddress() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("addresses.json");
         client = new TaxjarMock("TEST", interceptor);
+        Map<String, Object> params = new HashMap<>();
+        params.put("country", "US");
+        params.put("state", "AZ");
+        params.put("zip", "85297");
+        params.put("city", "Gilbert");
+        params.put("street", "3301 South Greenfield Rd");
+
+        AddressResponse res = client.validateAddress(params);
+
+        assertEquals("85297-2176", res.addresses.get(0).getZip());
+        assertEquals("3301 S Greenfield Rd", res.addresses.get(0).getStreet());
+        assertEquals("AZ", res.addresses.get(0).getState());
+        assertEquals("US", res.addresses.get(0).getCountry());
+        assertEquals("Gilbert", res.addresses.get(0).getCity());
+    }
+
+    public void testValidateAddressAsync() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("addresses.json");
+        client = new TaxjarMock("TEST", interceptor);
+        Map<String, Object> params = new HashMap<>();
+        params.put("country", "US");
+        params.put("state", "AZ");
+        params.put("zip", "85297");
+        params.put("city", "Gilbert");
+        params.put("street", "3301 South Greenfield Rd");
+
+        client.validateAddress(params, new Listener<AddressResponse>() {
+            @Override
+            public void onSuccess(AddressResponse res)
+            {
+                assertEquals("85297-2176", res.addresses.get(0).getZip());
+                assertEquals("3301 S Greenfield Rd", res.addresses.get(0).getStreet());
+                assertEquals("AZ", res.addresses.get(0).getState());
+                assertEquals("US", res.addresses.get(0).getCountry());
+                assertEquals("Gilbert", res.addresses.get(0).getCity());
+            }
+
+            @Override
+            public void onError(TaxjarException error)
+            {
+            }
+        });
+    }
+
+    public void testValidateAddressWithMultipleMatches() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("addresses_multiple.json");
+        client = new TaxjarMock("TEST", interceptor);
+        Map<String, Object> params = new HashMap<>();
+        params.put("state", "AZ");
+        params.put("city", "Phoenix");
+        params.put("street", "1109 9th");
+
+        AddressResponse res = client.validateAddress(params);
+
+        assertEquals("85007-3646", res.addresses.get(0).getZip());
+        assertEquals("1109 S 9th Ave", res.addresses.get(0).getStreet());
+        assertEquals("AZ", res.addresses.get(0).getState());
+        assertEquals("US", res.addresses.get(0).getCountry());
+        assertEquals("Phoenix", res.addresses.get(0).getCity());
+
+        assertEquals("85006-2734", res.addresses.get(1).getZip());
+        assertEquals("1109 N 9th St", res.addresses.get(1).getStreet());
+        assertEquals("AZ", res.addresses.get(1).getState());
+        assertEquals("US", res.addresses.get(1).getCountry());
+        assertEquals("Phoenix", res.addresses.get(1).getCity());
+    }
+
+    public void testValidateAddressWithMultipleMatchesAsync() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("addresses_multiple.json");
+        client = new TaxjarMock("TEST", interceptor);
+        Map<String, Object> params = new HashMap<>();
+        params.put("state", "AZ");
+        params.put("city", "Phoenix");
+        params.put("street", "1109 9th");
+
+        client.validateAddress(params, new Listener<AddressResponse>() {
+            @Override
+            public void onSuccess(AddressResponse res)
+            {
+                assertEquals("85007-3646", res.addresses.get(0).getZip());
+                assertEquals("1109 S 9th Ave", res.addresses.get(0).getStreet());
+                assertEquals("AZ", res.addresses.get(0).getState());
+                assertEquals("US", res.addresses.get(0).getCountry());
+                assertEquals("Phoenix", res.addresses.get(0).getCity());
+
+                assertEquals("85006-2734", res.addresses.get(1).getZip());
+                assertEquals("1109 N 9th St", res.addresses.get(1).getStreet());
+                assertEquals("AZ", res.addresses.get(1).getState());
+                assertEquals("US", res.addresses.get(1).getCountry());
+                assertEquals("Phoenix", res.addresses.get(1).getCity());
+            }
+
+            @Override
+            public void onError(TaxjarException error)
+            {
+            }
+        });
     }
 
     public void testValidate() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("validation.json");
+        client = new TaxjarMock("TEST", interceptor);
         Map<String, String> params = new HashMap<>();
         params.put("vat", "FR40303265045");
 
@@ -36,6 +136,8 @@ public class ValidationTest extends TestCase {
     }
 
     public void testValidateAsync() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("validation.json");
+        client = new TaxjarMock("TEST", interceptor);
         Map<String, String> params = new HashMap<>();
         params.put("vat", "FR40303265045");
 

--- a/src/test/resources/com/taxjar/fixtures/addresses.json
+++ b/src/test/resources/com/taxjar/fixtures/addresses.json
@@ -1,0 +1,11 @@
+{
+  "addresses": [
+    {
+      "zip": "85297-2176",
+      "street": "3301 S Greenfield Rd",
+      "state": "AZ",
+      "country": "US",
+      "city": "Gilbert"
+    }
+  ]
+}

--- a/src/test/resources/com/taxjar/fixtures/addresses_multiple.json
+++ b/src/test/resources/com/taxjar/fixtures/addresses_multiple.json
@@ -1,0 +1,18 @@
+{
+  "addresses": [
+    {
+      "zip": "85007-3646",
+      "street": "1109 S 9th Ave",
+      "state": "AZ",
+      "country": "US",
+      "city": "Phoenix"
+    },
+    {
+      "zip": "85006-2734",
+      "street": "1109 N 9th St",
+      "state": "AZ",
+      "country": "US",
+      "city": "Phoenix"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for TaxJar's address validation beta endpoint via `validateAddress`. At this time, address validation is only available for TaxJar Plus customers.