### PR TITLE
Custom Timeouts & Improved Exception Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,36 @@ public class SummarizedRatesExample {
 }
 ```
 
+## Custom Options
+
+You can pass additional options using `setApiConfig` or when instantiating the client for the following:
+
+### Timeouts
+
+The default timeout is 30 seconds (specified in milliseconds).
+
+```java
+import com.taxjar.Taxjar;
+import com.taxjar.exception.TaxjarException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomTimeoutExample {
+
+    public static void main(String[] args) {
+        // Custom timeout when instantiating the client
+        Map<String, Object> params = new HashMap<>();
+        params.put("timeout", 30 * 1000);
+
+        Taxjar client = new Taxjar("YOUR API TOKEN", params);
+
+        // Custom timeout via `setApiConfig`
+        client.setApiConfig("timeout", 30 * 1000);
+    }
+
+}
+```
+
 ## Sandbox Environment
 
 You can easily configure the client to use the [TaxJar Sandbox](https://developers.taxjar.com/api/reference/#sandbox-environment):
@@ -756,7 +786,7 @@ import java.util.Map;
 public class SandboxExample {
 
     public static void main(String[] args) {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("apiUrl", Taxjar.SANDBOX_API_URL);
 
         Taxjar client = new Taxjar("YOUR SANDBOX API TOKEN", params);

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <version>3.12.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -124,10 +124,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void categories(final Listener<CategoryResponse> listener) {
@@ -140,8 +138,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -150,7 +147,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CategoryResponse> call, Throwable t) {
-                t.printStackTrace();
+                listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -166,10 +163,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public RateResponse ratesForLocation(String zip, Map<String, String> params) throws TaxjarException {
@@ -183,10 +178,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void ratesForLocation(String zip, final Listener<RateResponse> listener) throws TaxjarException {
@@ -209,7 +202,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RateResponse> call, Throwable t) {
-                t.printStackTrace();
+                listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -234,7 +227,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RateResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -250,10 +243,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void taxForOrder(Map<String, Object> params, final Listener<TaxResponse> listener) {
@@ -276,7 +267,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<TaxResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -292,10 +283,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public OrdersResponse listOrders(Map<String, String> params) throws TaxjarException {
@@ -309,10 +298,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void listOrders(final Listener<OrdersResponse> listener) {
@@ -335,7 +322,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrdersResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -360,7 +347,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrdersResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -376,10 +363,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void showOrder(String transactionId, final Listener<OrderResponse> listener) {
@@ -402,7 +387,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrderResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -418,10 +403,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void createOrder(Map<String, Object> params, final Listener<OrderResponse> listener) {
@@ -444,7 +427,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrderResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -460,10 +443,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void updateOrder(String transactionId, Map<String, Object> params, final Listener<OrderResponse> listener) {
@@ -486,7 +467,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrderResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -502,10 +483,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void deleteOrder(String transactionId, final Listener<OrderResponse> listener) {
@@ -528,7 +507,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrderResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -544,10 +523,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public RefundsResponse listRefunds(Map<String, String> params) throws TaxjarException {
@@ -561,10 +538,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void listRefunds(final Listener<RefundsResponse> listener) {
@@ -587,7 +562,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundsResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -612,7 +587,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundsResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -628,10 +603,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void showRefund(String transactionId, final Listener<RefundResponse> listener) {
@@ -654,7 +627,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -670,10 +643,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void createRefund(Map<String, Object> params, final Listener<RefundResponse> listener) {
@@ -696,7 +667,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -712,10 +683,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void createRefund(String transactionId, Map<String, Object> params, final Listener<RefundResponse> listener) {
@@ -738,7 +707,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -754,10 +723,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void updateRefund(String transactionId, Map<String, Object> params, final Listener<RefundResponse> listener) {
@@ -780,7 +747,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -796,10 +763,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void deleteRefund(String transactionId, final Listener<RefundResponse> listener) {
@@ -822,7 +787,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -838,10 +803,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public CustomersResponse listCustomers(Map<String, String> params) throws TaxjarException {
@@ -855,10 +818,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void listCustomers(final Listener<CustomersResponse> listener) {
@@ -881,7 +842,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomersResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -906,7 +867,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomersResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -922,10 +883,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void showCustomer(String customerId, final Listener<CustomerResponse> listener) {
@@ -948,7 +907,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomerResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -964,10 +923,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void createCustomer(Map<String, Object> params, final Listener<CustomerResponse> listener) {
@@ -990,7 +947,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomerResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -1006,10 +963,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void updateCustomer(String customerId, Map<String, Object> params, final Listener<CustomerResponse> listener) {
@@ -1032,7 +987,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomerResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -1048,10 +1003,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void deleteCustomer(String customerId, final Listener<CustomerResponse> listener) {
@@ -1074,7 +1027,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomerResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -1090,10 +1043,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void nexusRegions(final Listener<RegionResponse> listener) {
@@ -1116,7 +1067,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RegionResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -1132,10 +1083,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void validateAddress(Map<String, Object> params, final Listener<AddressResponse> listener) {
@@ -1158,7 +1107,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<AddressResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -1174,10 +1123,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void validate(Map<String, String> params, final Listener<ValidationResponse> listener) {
@@ -1200,7 +1147,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<ValidationResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }
@@ -1216,10 +1163,8 @@ public class Taxjar {
                 throw new TaxjarException(response.errorBody().string());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TaxjarException(e.getMessage(), e);
         }
-
-        return null;
     }
 
     public void summaryRates(final Listener<SummaryRateResponse> listener) {
@@ -1242,7 +1187,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<SummaryRateResponse> call, Throwable t) {
-                t.printStackTrace();
+               listener.onError(new TaxjarException(t.getMessage()));
             }
         });
     }

--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -147,7 +147,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CategoryResponse> call, Throwable t) {
-                listener.onError(new TaxjarException(t.getMessage()));
+                listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -201,7 +201,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RateResponse> call, Throwable t) {
-                listener.onError(new TaxjarException(t.getMessage()));
+                listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -225,7 +225,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RateResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -264,7 +264,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<TaxResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -318,7 +318,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrdersResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -342,7 +342,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrdersResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -381,7 +381,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrderResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -420,7 +420,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrderResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -459,7 +459,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrderResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -498,7 +498,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<OrderResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -552,7 +552,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundsResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -576,7 +576,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundsResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -615,7 +615,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -654,7 +654,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -693,7 +693,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -732,7 +732,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -771,7 +771,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RefundResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -825,7 +825,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomersResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -849,7 +849,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomersResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -888,7 +888,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomerResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -927,7 +927,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomerResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -966,7 +966,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomerResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -1005,7 +1005,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<CustomerResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -1044,7 +1044,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<RegionResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -1083,7 +1083,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<AddressResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -1122,7 +1122,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<ValidationResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }
@@ -1161,7 +1161,7 @@ public class Taxjar {
 
             @Override
             public void onFailure(Call<SummaryRateResponse> call, Throwable t) {
-               listener.onError(new TaxjarException(t.getMessage()));
+               listener.onError(new TaxjarException(t.getMessage(), t));
             }
         });
     }

--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -192,8 +192,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -217,8 +216,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -257,8 +255,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -312,8 +309,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -337,8 +333,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -377,8 +372,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -417,8 +411,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -457,8 +450,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -497,8 +489,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -552,8 +543,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -577,8 +567,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -617,8 +606,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -657,8 +645,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -697,8 +684,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -737,8 +723,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -777,8 +762,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -832,8 +816,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -857,8 +840,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -897,8 +879,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -937,8 +918,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -977,8 +957,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -1017,8 +996,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -1057,8 +1035,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -1097,8 +1074,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -1137,8 +1113,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
@@ -1177,8 +1152,7 @@ public class Taxjar {
                     listener.onSuccess(response.body());
                 } else {
                     try {
-                        TaxjarException exception = new TaxjarException(response.errorBody().string());
-                        listener.onError(exception);
+                        listener.onError(new TaxjarException(response.errorBody().string()));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }

--- a/src/main/java/com/taxjar/exception/TaxjarException.java
+++ b/src/main/java/com/taxjar/exception/TaxjarException.java
@@ -2,23 +2,43 @@ package com.taxjar.exception;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 
 public class TaxjarException extends Exception {
     private Integer statusCode;
-    private String message;
 
-    public TaxjarException(String error) {
-        Gson gson = new Gson();
-        JsonObject json = gson.fromJson(error, JsonObject.class);
-        this.statusCode = json.get("status").getAsInt();
-        this.message = json.get("error").getAsString() + " - " + json.get("detail").getAsString();
+    public TaxjarException(String errorMessage) {
+        this(errorMessage, null);
+    }
+
+    public TaxjarException(String errorMessage, Throwable err) {
+        super(parseMessage(errorMessage), err);
+        this.statusCode = parseStatusCode(errorMessage);
     }
 
     public Integer getStatusCode() {
         return statusCode;
     }
 
-    public String getMessage() {
-        return message;
+    private static String parseMessage(String errorMessage) {
+        Gson gson = new Gson();
+
+        try {
+            JsonObject json = gson.fromJson(errorMessage, JsonObject.class);
+            return json.get("error").getAsString() + " - " + json.get("detail").getAsString();
+        } catch (JsonSyntaxException e) {
+            return errorMessage;
+        }
+    }
+
+    private static Integer parseStatusCode(String errorMessage) {
+        Gson gson = new Gson();
+
+        try {
+            JsonObject json = gson.fromJson(errorMessage, JsonObject.class);
+            return json.get("status").getAsInt();
+        } catch (JsonSyntaxException e) {
+            return 0;
+        }
     }
 }

--- a/src/test/java/com/taxjar/MockInterceptor.java
+++ b/src/test/java/com/taxjar/MockInterceptor.java
@@ -56,8 +56,12 @@ public class MockInterceptor implements Interceptor {
         ByteArrayOutputStream os = new ByteArrayOutputStream(1024);
         byte[] buf = new byte [1024];
 
-        for( int i = resource.read(buf); i > 0; i = resource.read(buf)) {
-            os.write(buf,0,i);
+        try {
+            for (int i = resource.read(buf); i > 0; i = resource.read(buf)) {
+                os.write(buf, 0, i);
+            }
+        } catch (RuntimeException e) {
+            // No-op
         }
 
         return os.toString("utf8");

--- a/src/test/java/com/taxjar/TaxjarMock.java
+++ b/src/test/java/com/taxjar/TaxjarMock.java
@@ -10,6 +10,8 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public final class TaxjarMock extends Taxjar {
     public TaxjarMock(final String apiToken, Interceptor interceptor) {
@@ -23,7 +25,51 @@ public final class TaxjarMock extends Taxjar {
                         .build();
                 return chain.proceed(newRequest);
             }
-        }).addInterceptor(interceptor).build();
+        }).addInterceptor(interceptor)
+                .connectTimeout(timeout, TimeUnit.MILLISECONDS)
+                .writeTimeout(timeout, TimeUnit.MILLISECONDS)
+                .readTimeout(timeout, TimeUnit.MILLISECONDS)
+                .build();
+
+        Gson gson = new GsonBuilder()
+                .setLenient()
+                .create();
+
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(DEFAULT_API_URL + "/" + API_VERSION + "/")
+                .addConverterFactory(GsonConverterFactory.create(gson))
+                .client(client)
+                .build();
+
+        apiService = retrofit.create(Endpoints.class);
+    }
+
+    public TaxjarMock(final String apiToken, Map<String, Object> params, Interceptor interceptor) {
+        super(apiToken, params);
+
+        if (params != null) {
+            for (Map.Entry<String, Object> param : params.entrySet()) {
+                try {
+                    getClass().getDeclaredField(param.getKey()).set(this, param.getValue());
+                } catch (NoSuchFieldException | IllegalAccessException ex) {
+                    // No-op
+                }
+            }
+        }
+
+        final OkHttpClient client = new OkHttpClient.Builder().addInterceptor(new Interceptor() {
+            @Override
+            public okhttp3.Response intercept(Chain chain) throws IOException {
+                Request newRequest = chain.request().newBuilder()
+                        .addHeader("Authorization", "Bearer " + apiToken)
+                        .build();
+                return chain.proceed(newRequest);
+            }
+        }).addInterceptor(interceptor)
+                .connectTimeout(timeout, TimeUnit.MILLISECONDS)
+                .writeTimeout(timeout, TimeUnit.MILLISECONDS)
+                .readTimeout(timeout, TimeUnit.MILLISECONDS)
+                .build();
 
         Gson gson = new GsonBuilder()
                 .setLenient()

--- a/src/test/java/com/taxjar/config/ConfigTest.java
+++ b/src/test/java/com/taxjar/config/ConfigTest.java
@@ -14,11 +14,13 @@ public class ConfigTest extends TestCase {
     }
 
     public void testClientParams() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("apiUrl", Taxjar.SANDBOX_API_URL);
+        params.put("timeout", 60 * 1000);
 
         client = new Taxjar("TEST", params);
         assertEquals(client.getApiConfig("apiUrl"), Taxjar.SANDBOX_API_URL);
+        assertEquals(client.getApiConfig("timeout"), "60000");
     }
 
     public void testGetApiConfig() {
@@ -32,5 +34,8 @@ public class ConfigTest extends TestCase {
 
         client.setApiConfig("apiToken", "foobar");
         assertEquals(client.getApiConfig("apiToken"), "foobar");
+
+        client.setApiConfig("timeout", 60 * 1000);
+        assertEquals(client.getApiConfig("timeout"), "60000");
     }
 }

--- a/src/test/java/com/taxjar/exception/ExceptionTest.java
+++ b/src/test/java/com/taxjar/exception/ExceptionTest.java
@@ -1,25 +1,27 @@
 package com.taxjar.exception;
 
 import com.taxjar.MockInterceptor;
+import com.taxjar.Taxjar;
 import com.taxjar.TaxjarMock;
 import com.taxjar.model.categories.CategoryResponse;
+import com.taxjar.net.Listener;
 import junit.framework.TestCase;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class ExceptionTest extends TestCase {
-    private TaxjarMock client;
+    public void testException() {
+        TaxjarException e = null;
 
-    protected void setUp() {
         Map<String, Object> opts = new HashMap<>();
         opts.put("code", 400);
         MockInterceptor interceptor = new MockInterceptor("error.json", opts);
-        client = new TaxjarMock("TEST", interceptor);
-    }
-
-    public void testException() {
-        TaxjarException e = null;
+        TaxjarMock client = new TaxjarMock("TEST", interceptor);
 
         try {
             CategoryResponse res = client.categories();
@@ -30,5 +32,85 @@ public class ExceptionTest extends TestCase {
         assertTrue(e instanceof TaxjarException);
         assertEquals("Bad Request - Your request format is bad.", e.getMessage());
         assertEquals((Integer) 400, e.getStatusCode());
+    }
+
+    public void testExceptionAsync() throws InterruptedException {
+        Map<String, Object> opts = new HashMap<>();
+        opts.put("code", 400);
+        MockInterceptor interceptor = new MockInterceptor("error.json", opts);
+        TaxjarMock client = new TaxjarMock("TEST", interceptor);
+
+        client.categories(new Listener<CategoryResponse>() {
+            @Override
+            public void onSuccess(CategoryResponse res)
+            {
+                fail("Call was successful");
+            }
+
+            @Override
+            public void onError(TaxjarException e)
+            {
+                assertTrue(e instanceof TaxjarException);
+                assertEquals("Bad Request - Your request format is bad.", e.getMessage());
+                assertEquals((Integer) 400, e.getStatusCode());
+            }
+        });
+
+        Thread.sleep(1000);
+    }
+
+    public void testTimeoutException() throws IOException {
+        TaxjarException e = null;
+        MockWebServer server = new MockWebServer();
+
+        server.enqueue(new MockResponse().setBody("{}").setBodyDelay(800, TimeUnit.MILLISECONDS));
+        server.start();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("apiUrl", "http://" + server.getHostName() + ":" + server.getPort());
+        params.put("timeout", 500);
+        Taxjar client = new Taxjar("TEST", params);
+
+        try {
+            CategoryResponse res = client.categories();
+        } catch (TaxjarException ex) {
+            e = ex;
+        }
+
+        assertTrue(e instanceof TaxjarException);
+        assertEquals("timeout", e.getMessage());
+
+        server.shutdown();
+    }
+
+    public void testTimeoutExceptionAsync() throws IOException, InterruptedException {
+        MockWebServer server = new MockWebServer();
+
+        server.enqueue(new MockResponse().setBody("{}").setBodyDelay(800, TimeUnit.MILLISECONDS));
+        server.start();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("apiUrl", "http://" + server.getHostName() + ":" + server.getPort());
+        params.put("timeout", 500);
+        Taxjar client = new Taxjar("TEST", params);
+
+        client.categories(new Listener<CategoryResponse>() {
+            @Override
+            public void onSuccess(CategoryResponse res)
+            {
+                fail("Call was successful");
+            }
+
+            @Override
+            public void onError(TaxjarException e)
+            {
+                assertTrue(e instanceof TaxjarException);
+                assertEquals("timeout", e.getMessage());
+            }
+        });
+
+        Thread.sleep(1000);
+
+        server.shutdown();
     }
 }


### PR DESCRIPTION
Pass a custom timeout (in milliseconds) when instantiating the TaxJar client or using the `setApiConfig` method:

```java
Map<String, Object> params = new HashMap<>();
params.put("timeout", 60 * 1000);

client = new Taxjar("YOUR API TOKEN", params);
```

This PR changes the `params` type from `Map<String, String>` to `Map<String, Object>`, so we'll need to create a new major version (v2.0). Resolves #6.