### PR TITLE
Update `validate` method to `validateVat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ public class ValidateExample {
             Map<String, String> params = new HashMap<>();
             params.put("vat", "FR40303265045");
 
-            ValidationResponse res = client.validate(params);
+            ValidationResponse res = client.validateVat(params);
         } catch (TaxjarException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -1088,7 +1088,7 @@ public class Taxjar {
         });
     }
 
-    public ValidationResponse validate(Map<String, String> params) throws TaxjarException {
+    public ValidationResponse validateVat(Map<String, String> params) throws TaxjarException {
         Call<ValidationResponse> call = apiService.getValidation(params);
 
         try {
@@ -1103,7 +1103,7 @@ public class Taxjar {
         }
     }
 
-    public void validate(Map<String, String> params, final Listener<ValidationResponse> listener) {
+    public void validateVat(Map<String, String> params, final Listener<ValidationResponse> listener) {
         Call<ValidationResponse> call = apiService.getValidation(params);
 
         call.enqueue(new Callback<ValidationResponse>() {

--- a/src/test/java/com/taxjar/functional/ValidationTest.java
+++ b/src/test/java/com/taxjar/functional/ValidationTest.java
@@ -122,7 +122,7 @@ public class ValidationTest extends TestCase {
         Map<String, String> params = new HashMap<>();
         params.put("vat", "FR40303265045");
 
-        ValidationResponse res = client.validate(params);
+        ValidationResponse res = client.validateVat(params);
 
         assertEquals((Boolean) true, res.validation.getValid());
         assertEquals((Boolean) true, res.validation.getExists());
@@ -141,7 +141,7 @@ public class ValidationTest extends TestCase {
         Map<String, String> params = new HashMap<>();
         params.put("vat", "FR40303265045");
 
-        client.validate(params, new Listener<ValidationResponse>() {
+        client.validateVat(params, new Listener<ValidationResponse>() {
             @Override
             public void onSuccess(ValidationResponse res)
             {


### PR DESCRIPTION
Now that we provide a `validateAddress` method for Plus customers, rename `validate` to `validateVat` to make things clearer.