### PR TITLE
Thread-Safe API Client Configuration

### DIFF
--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -39,9 +39,9 @@ public class Taxjar {
     public static final String API_VERSION = "v2";
     public static final String VERSION = "2.0.0";
     protected static Endpoints apiService;
-    protected static String apiUrl;
-    protected static String apiToken;
-    protected static long timeout = 30000;
+    protected String apiUrl;
+    protected String apiToken;
+    protected long timeout = 30000;
 
     public Taxjar(final String apiToken) {
         this(apiToken, null);

--- a/src/test/java/com/taxjar/config/ConfigTest.java
+++ b/src/test/java/com/taxjar/config/ConfigTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 public class ConfigTest extends TestCase {
     private Taxjar client;
+    private Taxjar client2;
 
     protected void setUp() {
         client = new Taxjar("TEST");
@@ -21,6 +22,10 @@ public class ConfigTest extends TestCase {
         client = new Taxjar("TEST", params);
         assertEquals(client.getApiConfig("apiUrl"), Taxjar.SANDBOX_API_URL);
         assertEquals(client.getApiConfig("timeout"), "60000");
+
+        client2 = new Taxjar("TEST2");
+        assertEquals(client.getApiConfig("apiToken"), "TEST");
+        assertEquals(client2.getApiConfig("apiToken"), "TEST2");
     }
 
     public void testGetApiConfig() {


### PR DESCRIPTION
If the client is instantiated multiple times in a multi-threaded environment for different customers, make sure config params are thread-safe and not shared across multiple clients. Fixes #14.