### PR TITLE
Implement `provider` param in transaction methods

### DIFF
--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -176,8 +176,18 @@ public class Taxjar {
         return new ApiRequest<>(call).execute();
     }
 
+    public OrderResponse showOrder(String transactionId, Map<String, String> params) throws TaxjarException {
+        Call<OrderResponse> call = apiService.getOrder(transactionId, params);
+        return new ApiRequest<>(call).execute();
+    }
+
     public void showOrder(String transactionId, final Listener<OrderResponse> listener) {
         Call<OrderResponse> call = apiService.getOrder(transactionId);
+        call.enqueue(new ApiCallback<>(listener));
+    }
+
+    public void showOrder(String transactionId, Map<String, String> params, final Listener<OrderResponse> listener) {
+        Call<OrderResponse> call = apiService.getOrder(transactionId, params);
         call.enqueue(new ApiCallback<>(listener));
     }
 
@@ -206,8 +216,18 @@ public class Taxjar {
         return new ApiRequest<>(call).execute();
     }
 
+    public OrderResponse deleteOrder(String transactionId, Map<String, String> params) throws TaxjarException {
+        Call<OrderResponse> call = apiService.deleteOrder(transactionId, params);
+        return new ApiRequest<>(call).execute();
+    }
+
     public void deleteOrder(String transactionId, final Listener<OrderResponse> listener) {
         Call<OrderResponse> call = apiService.deleteOrder(transactionId);
+        call.enqueue(new ApiCallback<>(listener));
+    }
+
+    public void deleteOrder(String transactionId, Map<String, String> params, final Listener<OrderResponse> listener) {
+        Call<OrderResponse> call = apiService.deleteOrder(transactionId, params);
         call.enqueue(new ApiCallback<>(listener));
     }
 
@@ -236,8 +256,18 @@ public class Taxjar {
         return new ApiRequest<>(call).execute();
     }
 
+    public RefundResponse showRefund(String transactionId, Map<String, String> params) throws TaxjarException {
+        Call<RefundResponse> call = apiService.getRefund(transactionId, params);
+        return new ApiRequest<>(call).execute();
+    }
+
     public void showRefund(String transactionId, final Listener<RefundResponse> listener) {
         Call<RefundResponse> call = apiService.getRefund(transactionId);
+        call.enqueue(new ApiCallback<>(listener));
+    }
+
+    public void showRefund(String transactionId, Map<String, String> params, final Listener<RefundResponse> listener) {
+        Call<RefundResponse> call = apiService.getRefund(transactionId, params);
         call.enqueue(new ApiCallback<>(listener));
     }
 
@@ -276,8 +306,18 @@ public class Taxjar {
         return new ApiRequest<>(call).execute();
     }
 
+    public RefundResponse deleteRefund(String transactionId, Map<String, String> params) throws TaxjarException {
+        Call<RefundResponse> call = apiService.deleteRefund(transactionId, params);
+        return new ApiRequest<>(call).execute();
+    }
+
     public void deleteRefund(String transactionId, final Listener<RefundResponse> listener) {
         Call<RefundResponse> call = apiService.deleteRefund(transactionId);
+        call.enqueue(new ApiCallback<>(listener));
+    }
+
+    public void deleteRefund(String transactionId, Map<String, String> params, final Listener<RefundResponse> listener) {
+        Call<RefundResponse> call = apiService.deleteRefund(transactionId, params);
         call.enqueue(new ApiCallback<>(listener));
     }
 

--- a/src/main/java/com/taxjar/model/transactions/Order.java
+++ b/src/main/java/com/taxjar/model/transactions/Order.java
@@ -13,6 +13,9 @@ public class Order {
     @SerializedName("transaction_date")
     String transactionDate;
 
+    @SerializedName("provider")
+    String provider;
+
     @SerializedName("from_country")
     String fromCountry;
 
@@ -61,6 +64,10 @@ public class Order {
 
     public String getTransactionDate() {
         return transactionDate;
+    }
+
+    public String getProvider() {
+        return provider;
     }
 
     public String getFromCountry() {

--- a/src/main/java/com/taxjar/model/transactions/Refund.java
+++ b/src/main/java/com/taxjar/model/transactions/Refund.java
@@ -17,6 +17,9 @@ public class Refund {
     @SerializedName("transaction_reference_id")
     String transactionReferenceId;
 
+    @SerializedName("provider")
+    String provider;
+
     @SerializedName("from_country")
     String fromCountry;
 
@@ -69,6 +72,10 @@ public class Refund {
 
     public String getTransactionDate() {
         return transactionDate;
+    }
+
+    public String getProvider() {
+        return provider;
     }
 
     public String getTransactionReferenceId() {

--- a/src/main/java/com/taxjar/net/Endpoints.java
+++ b/src/main/java/com/taxjar/net/Endpoints.java
@@ -42,6 +42,9 @@ public interface Endpoints
     @GET("transactions/orders/{transactionId}")
     Call<OrderResponse> getOrder(@Path("transactionId") String transactionId);
 
+    @GET("transactions/orders/{transactionId}")
+    Call<OrderResponse> getOrder(@Path("transactionId") String transactionId, @QueryMap Map<String, String> params);
+
     @POST("transactions/orders")
     Call<OrderResponse> createOrder(@Body Map<String, Object> params);
 
@@ -50,6 +53,9 @@ public interface Endpoints
 
     @DELETE("transactions/orders/{transactionId}")
     Call<OrderResponse> deleteOrder(@Path("transactionId") String transactionId);
+
+    @DELETE("transactions/orders/{transactionId}")
+    Call<OrderResponse> deleteOrder(@Path("transactionId") String transactionId, @QueryMap Map<String, String> params);
 
     @GET("transactions/refunds")
     Call<RefundsResponse> getRefunds();
@@ -60,6 +66,9 @@ public interface Endpoints
     @GET("transactions/refunds/{transactionId}")
     Call<RefundResponse> getRefund(@Path("transactionId") String transactionId);
 
+    @GET("transactions/refunds/{transactionId}")
+    Call<RefundResponse> getRefund(@Path("transactionId") String transactionId, @QueryMap Map<String, String> params);
+
     @POST("transactions/refunds")
     Call<RefundResponse> createRefund(@Body Map<String, Object> params);
 
@@ -68,6 +77,9 @@ public interface Endpoints
 
     @DELETE("transactions/refunds/{transactionId}")
     Call<RefundResponse> deleteRefund(@Path("transactionId") String transactionId);
+
+    @DELETE("transactions/refunds/{transactionId}")
+    Call<RefundResponse> deleteRefund(@Path("transactionId") String transactionId, @QueryMap Map<String, String> params);
 
     @GET("customers")
     Call<CustomersResponse> getCustomers();

--- a/src/test/java/com/taxjar/functional/OrderTest.java
+++ b/src/test/java/com/taxjar/functional/OrderTest.java
@@ -29,6 +29,7 @@ public class OrderTest extends TestCase {
         Map<String, String> params = new HashMap<>();
         params.put("from_transaction_date", "2015/05/01");
         params.put("to_transaction_date", "2015/05/31");
+        params.put("provider", "api");
 
         OrdersResponse res = client.listOrders(params);
         assertEquals("123", res.orders.get(0));
@@ -61,6 +62,7 @@ public class OrderTest extends TestCase {
         Map<String, String> params = new HashMap<>();
         params.put("from_transaction_date", "2015/05/01");
         params.put("to_transaction_date", "2015/05/31");
+        params.put("provider", "api");
 
         client.listOrders(params, new Listener<OrdersResponse>() {
             @Override
@@ -85,6 +87,37 @@ public class OrderTest extends TestCase {
         assertEquals("123", res.order.getTransactionId());
         assertEquals((Integer) 10649, res.order.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+        assertEquals("api", res.order.getProvider());
+        assertEquals("US", res.order.getToCountry());
+        assertEquals("90002", res.order.getToZip());
+        assertEquals("CA", res.order.getToState());
+        assertEquals("LOS ANGELES", res.order.getToCity());
+        assertEquals("123 Palm Grove Ln", res.order.getToStreet());
+        assertEquals(17f, res.order.getAmount());
+        assertEquals(2f, res.order.getShipping());
+        assertEquals(0.95f, res.order.getSalesTax());
+        assertEquals("1", res.order.getLineItems().get(0).getId());
+        assertEquals((Integer) 1, res.order.getLineItems().get(0).getQuantity());
+        assertEquals("12-34243-0", res.order.getLineItems().get(0).getProductIdentifier());
+        assertEquals("Heavy Widget", res.order.getLineItems().get(0).getDescription());
+        assertEquals("20010", res.order.getLineItems().get(0).getProductTaxCode());
+        assertEquals(15f, res.order.getLineItems().get(0).getUnitPrice());
+        assertEquals(0f, res.order.getLineItems().get(0).getDiscount());
+        assertEquals(0.95f, res.order.getLineItems().get(0).getSalesTax());
+    }
+
+    public void testShowOrderWithParams() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("orders/show.json");
+        client = new TaxjarMock("TEST", interceptor);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("provider", "api");
+
+        OrderResponse res = client.showOrder("123", params);
+        assertEquals("123", res.order.getTransactionId());
+        assertEquals((Integer) 10649, res.order.getUserId());
+        assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+        assertEquals("api", res.order.getProvider());
         assertEquals("US", res.order.getToCountry());
         assertEquals("90002", res.order.getToZip());
         assertEquals("CA", res.order.getToState());
@@ -114,6 +147,7 @@ public class OrderTest extends TestCase {
                 assertEquals("123", res.order.getTransactionId());
                 assertEquals((Integer) 10649, res.order.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+                assertEquals("api", res.order.getProvider());
                 assertEquals("US", res.order.getToCountry());
                 assertEquals("90002", res.order.getToZip());
                 assertEquals("CA", res.order.getToState());
@@ -139,6 +173,44 @@ public class OrderTest extends TestCase {
         });
     }
 
+    public void testShowOrderAsyncWithParams() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("orders/show.json");
+        client = new TaxjarMock("TEST", interceptor);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("provider", "api");
+
+        client.showOrder("123", params, new Listener<OrderResponse>() {
+            @Override
+            public void onSuccess(OrderResponse res) {
+                assertEquals("123", res.order.getTransactionId());
+                assertEquals((Integer) 10649, res.order.getUserId());
+                assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+                assertEquals("api", res.order.getProvider());
+                assertEquals("US", res.order.getToCountry());
+                assertEquals("90002", res.order.getToZip());
+                assertEquals("CA", res.order.getToState());
+                assertEquals("LOS ANGELES", res.order.getToCity());
+                assertEquals("123 Palm Grove Ln", res.order.getToStreet());
+                assertEquals(17f, res.order.getAmount());
+                assertEquals(2f, res.order.getShipping());
+                assertEquals(0.95f, res.order.getSalesTax());
+                assertEquals("1", res.order.getLineItems().get(0).getId());
+                assertEquals((Integer) 1, res.order.getLineItems().get(0).getQuantity());
+                assertEquals("12-34243-0", res.order.getLineItems().get(0).getProductIdentifier());
+                assertEquals("Heavy Widget", res.order.getLineItems().get(0).getDescription());
+                assertEquals("20010", res.order.getLineItems().get(0).getProductTaxCode());
+                assertEquals(15f, res.order.getLineItems().get(0).getUnitPrice());
+                assertEquals(0f, res.order.getLineItems().get(0).getDiscount());
+                assertEquals(0.95f, res.order.getLineItems().get(0).getSalesTax());
+            }
+
+            @Override
+            public void onError(TaxjarException error) {
+            }
+        });
+    }
+
     public void testCreateOrder() throws TaxjarException {
         MockInterceptor interceptor = new MockInterceptor("orders/show.json");
         client = new TaxjarMock("TEST", interceptor);
@@ -146,6 +218,7 @@ public class OrderTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "123");
         params.put("transaction_date", "2015/05/04");
+        params.put("provider", "api");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -169,6 +242,7 @@ public class OrderTest extends TestCase {
         assertEquals("123", res.order.getTransactionId());
         assertEquals((Integer) 10649, res.order.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+        assertEquals("api", res.order.getProvider());
         assertEquals("US", res.order.getToCountry());
         assertEquals("90002", res.order.getToZip());
         assertEquals("CA", res.order.getToState());
@@ -194,6 +268,7 @@ public class OrderTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "123");
         params.put("transaction_date", "2015/05/04");
+        params.put("provider", "api");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -220,6 +295,7 @@ public class OrderTest extends TestCase {
                 assertEquals("123", res.order.getTransactionId());
                 assertEquals((Integer) 10649, res.order.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+                assertEquals("api", res.order.getProvider());
                 assertEquals("US", res.order.getToCountry());
                 assertEquals("90002", res.order.getToZip());
                 assertEquals("CA", res.order.getToState());
@@ -275,6 +351,7 @@ public class OrderTest extends TestCase {
         assertEquals("123", res.order.getTransactionId());
         assertEquals((Integer) 10649, res.order.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+        assertEquals("api", res.order.getProvider());
         assertEquals("US", res.order.getToCountry());
         assertEquals("90002", res.order.getToZip());
         assertEquals("CA", res.order.getToState());
@@ -326,6 +403,7 @@ public class OrderTest extends TestCase {
                 assertEquals("123", res.order.getTransactionId());
                 assertEquals((Integer) 10649, res.order.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+                assertEquals("api", res.order.getProvider());
                 assertEquals("US", res.order.getToCountry());
                 assertEquals("90002", res.order.getToZip());
                 assertEquals("CA", res.order.getToState());
@@ -359,6 +437,30 @@ public class OrderTest extends TestCase {
         assertEquals("123", res.order.getTransactionId());
         assertEquals((Integer) 10649, res.order.getUserId());
         assertEquals(null, res.order.getTransactionDate());
+        assertEquals("api", res.order.getProvider());
+        assertEquals(null, res.order.getToCountry());
+        assertEquals(null, res.order.getToZip());
+        assertEquals(null, res.order.getToState());
+        assertEquals(null, res.order.getToCity());
+        assertEquals(null, res.order.getToStreet());
+        assertEquals(null, res.order.getAmount());
+        assertEquals(null, res.order.getShipping());
+        assertEquals(null, res.order.getSalesTax());
+        assertEquals(Collections.emptyList(), res.order.getLineItems());
+    }
+
+    public void testDeleteOrderWithParams() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("orders/delete.json");
+        client = new TaxjarMock("TEST", interceptor);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("provider", "api");
+
+        OrderResponse res = client.deleteOrder("123", params);
+        assertEquals("123", res.order.getTransactionId());
+        assertEquals((Integer) 10649, res.order.getUserId());
+        assertEquals(null, res.order.getTransactionDate());
+        assertEquals("api", res.order.getProvider());
         assertEquals(null, res.order.getToCountry());
         assertEquals(null, res.order.getToZip());
         assertEquals(null, res.order.getToState());
@@ -381,6 +483,7 @@ public class OrderTest extends TestCase {
                 assertEquals("123", res.order.getTransactionId());
                 assertEquals((Integer) 10649, res.order.getUserId());
                 assertEquals(null, res.order.getTransactionDate());
+                assertEquals("api", res.order.getProvider());
                 assertEquals(null, res.order.getToCountry());
                 assertEquals(null, res.order.getToZip());
                 assertEquals(null, res.order.getToState());
@@ -395,6 +498,37 @@ public class OrderTest extends TestCase {
             @Override
             public void onError(TaxjarException error)
             {
+            }
+        });
+    }
+
+    public void testDeleteOrderAsyncWithParams() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("orders/delete.json");
+        client = new TaxjarMock("TEST", interceptor);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("provider", "api");
+
+        client.deleteOrder("123", params, new Listener<OrderResponse>() {
+            @Override
+            public void onSuccess(OrderResponse res) {
+                assertEquals("123", res.order.getTransactionId());
+                assertEquals((Integer) 10649, res.order.getUserId());
+                assertEquals(null, res.order.getTransactionDate());
+                assertEquals("api", res.order.getProvider());
+                assertEquals(null, res.order.getToCountry());
+                assertEquals(null, res.order.getToZip());
+                assertEquals(null, res.order.getToState());
+                assertEquals(null, res.order.getToCity());
+                assertEquals(null, res.order.getToStreet());
+                assertEquals(null, res.order.getAmount());
+                assertEquals(null, res.order.getShipping());
+                assertEquals(null, res.order.getSalesTax());
+                assertEquals(Collections.emptyList(), res.order.getLineItems());
+            }
+
+            @Override
+            public void onError(TaxjarException error) {
             }
         });
     }

--- a/src/test/java/com/taxjar/functional/RefundTest.java
+++ b/src/test/java/com/taxjar/functional/RefundTest.java
@@ -29,6 +29,7 @@ public class RefundTest extends TestCase {
         Map<String, String> params = new HashMap<>();
         params.put("from_transaction_date", "2015/05/01");
         params.put("to_transaction_date", "2015/05/31");
+        params.put("provider", "api");
 
         RefundsResponse res = client.listRefunds(params);
         assertEquals("321", res.refunds.get(0));
@@ -61,6 +62,7 @@ public class RefundTest extends TestCase {
         Map<String, String> params = new HashMap<>();
         params.put("from_transaction_date", "2015/05/01");
         params.put("to_transaction_date", "2015/05/31");
+        params.put("provider", "api");
 
         client.listRefunds(params, new Listener<RefundsResponse>() {
             @Override
@@ -85,6 +87,38 @@ public class RefundTest extends TestCase {
         assertEquals("321", res.refund.getTransactionId());
         assertEquals((Integer) 10649, res.refund.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
+        assertEquals("api", res.refund.getProvider());
+        assertEquals("123", res.refund.getTransactionReferenceId());
+        assertEquals("US", res.refund.getToCountry());
+        assertEquals("90002", res.refund.getToZip());
+        assertEquals("CA", res.refund.getToState());
+        assertEquals("LOS ANGELES", res.refund.getToCity());
+        assertEquals("123 Palm Grove Ln", res.refund.getToStreet());
+        assertEquals(17f, res.refund.getAmount());
+        assertEquals(2f, res.refund.getShipping());
+        assertEquals(0.95f, res.refund.getSalesTax());
+        assertEquals("1", res.refund.getLineItems().get(0).getId());
+        assertEquals((Integer) 1, res.refund.getLineItems().get(0).getQuantity());
+        assertEquals("12-34243-0", res.refund.getLineItems().get(0).getProductIdentifier());
+        assertEquals("Heavy Widget", res.refund.getLineItems().get(0).getDescription());
+        assertEquals("20010", res.refund.getLineItems().get(0).getProductTaxCode());
+        assertEquals(15f, res.refund.getLineItems().get(0).getUnitPrice());
+        assertEquals(0f, res.refund.getLineItems().get(0).getDiscount());
+        assertEquals(0.95f, res.refund.getLineItems().get(0).getSalesTax());
+    }
+
+    public void testShowRefundWithParams() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("refunds/show.json");
+        client = new TaxjarMock("TEST", interceptor);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("provider", "api");
+
+        RefundResponse res = client.showRefund("321", params);
+        assertEquals("321", res.refund.getTransactionId());
+        assertEquals((Integer) 10649, res.refund.getUserId());
+        assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
+        assertEquals("api", res.refund.getProvider());
         assertEquals("123", res.refund.getTransactionReferenceId());
         assertEquals("US", res.refund.getToCountry());
         assertEquals("90002", res.refund.getToZip());
@@ -116,6 +150,7 @@ public class RefundTest extends TestCase {
                 assertEquals((Integer) 10649, res.refund.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
                 assertEquals("123", res.refund.getTransactionReferenceId());
+                assertEquals("api", res.refund.getProvider());
                 assertEquals("US", res.refund.getToCountry());
                 assertEquals("90002", res.refund.getToZip());
                 assertEquals("CA", res.refund.getToState());
@@ -141,6 +176,45 @@ public class RefundTest extends TestCase {
         });
     }
 
+    public void testShowRefundAsyncWithParams() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("refunds/show.json");
+        client = new TaxjarMock("TEST", interceptor);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("provider", "api");
+
+        client.showRefund("321", params, new Listener<RefundResponse>() {
+            @Override
+            public void onSuccess(RefundResponse res) {
+                assertEquals("321", res.refund.getTransactionId());
+                assertEquals((Integer) 10649, res.refund.getUserId());
+                assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
+                assertEquals("123", res.refund.getTransactionReferenceId());
+                assertEquals("api", res.refund.getProvider());
+                assertEquals("US", res.refund.getToCountry());
+                assertEquals("90002", res.refund.getToZip());
+                assertEquals("CA", res.refund.getToState());
+                assertEquals("LOS ANGELES", res.refund.getToCity());
+                assertEquals("123 Palm Grove Ln", res.refund.getToStreet());
+                assertEquals(17f, res.refund.getAmount());
+                assertEquals(2f, res.refund.getShipping());
+                assertEquals(0.95f, res.refund.getSalesTax());
+                assertEquals("1", res.refund.getLineItems().get(0).getId());
+                assertEquals((Integer) 1, res.refund.getLineItems().get(0).getQuantity());
+                assertEquals("12-34243-0", res.refund.getLineItems().get(0).getProductIdentifier());
+                assertEquals("Heavy Widget", res.refund.getLineItems().get(0).getDescription());
+                assertEquals("20010", res.refund.getLineItems().get(0).getProductTaxCode());
+                assertEquals(15f, res.refund.getLineItems().get(0).getUnitPrice());
+                assertEquals(0f, res.refund.getLineItems().get(0).getDiscount());
+                assertEquals(0.95f, res.refund.getLineItems().get(0).getSalesTax());
+            }
+
+            @Override
+            public void onError(TaxjarException error) {
+            }
+        });
+    }
+
     public void testCreateRefund() throws TaxjarException {
         MockInterceptor interceptor = new MockInterceptor("refunds/show.json");
         client = new TaxjarMock("TEST", interceptor);
@@ -148,6 +222,7 @@ public class RefundTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "321");
         params.put("transaction_date", "2015/05/04");
+        params.put("provider", "api");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -171,6 +246,7 @@ public class RefundTest extends TestCase {
         assertEquals("321", res.refund.getTransactionId());
         assertEquals((Integer) 10649, res.refund.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
+        assertEquals("api", res.refund.getProvider());
         assertEquals("123", res.refund.getTransactionReferenceId());
         assertEquals("US", res.refund.getToCountry());
         assertEquals("90002", res.refund.getToZip());
@@ -197,6 +273,7 @@ public class RefundTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "321");
         params.put("transaction_date", "2015/05/04");
+        params.put("provider", "api");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -224,6 +301,7 @@ public class RefundTest extends TestCase {
                 assertEquals((Integer) 10649, res.refund.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
                 assertEquals("123", res.refund.getTransactionReferenceId());
+                assertEquals("api", res.refund.getProvider());
                 assertEquals("US", res.refund.getToCountry());
                 assertEquals("90002", res.refund.getToZip());
                 assertEquals("CA", res.refund.getToState());
@@ -280,6 +358,7 @@ public class RefundTest extends TestCase {
         assertEquals((Integer) 10649, res.refund.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
         assertEquals("123", res.refund.getTransactionReferenceId());
+        assertEquals("api", res.refund.getProvider());
         assertEquals("US", res.refund.getToCountry());
         assertEquals("90002", res.refund.getToZip());
         assertEquals("CA", res.refund.getToState());
@@ -332,6 +411,7 @@ public class RefundTest extends TestCase {
                 assertEquals((Integer) 10649, res.refund.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
                 assertEquals("123", res.refund.getTransactionReferenceId());
+                assertEquals("api", res.refund.getProvider());
                 assertEquals("US", res.refund.getToCountry());
                 assertEquals("90002", res.refund.getToZip());
                 assertEquals("CA", res.refund.getToState());
@@ -365,6 +445,7 @@ public class RefundTest extends TestCase {
         assertEquals("321", res.refund.getTransactionId());
         assertEquals((Integer) 10649, res.refund.getUserId());
         assertEquals(null, res.refund.getTransactionDate());
+        assertEquals("api", res.refund.getProvider());
         assertEquals(null, res.refund.getToCountry());
         assertEquals(null, res.refund.getToZip());
         assertEquals(null, res.refund.getToState());
@@ -376,7 +457,30 @@ public class RefundTest extends TestCase {
         assertEquals(Collections.emptyList(), res.refund.getLineItems());
     }
 
-    public void testDeleteOrderAsync() throws TaxjarException {
+    public void testDeleteRefundWithParams() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("refunds/delete.json");
+        client = new TaxjarMock("TEST", interceptor);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("provider", "api");
+
+        RefundResponse res = client.deleteRefund("321", params);
+        assertEquals("321", res.refund.getTransactionId());
+        assertEquals((Integer) 10649, res.refund.getUserId());
+        assertEquals(null, res.refund.getTransactionDate());
+        assertEquals("api", res.refund.getProvider());
+        assertEquals(null, res.refund.getToCountry());
+        assertEquals(null, res.refund.getToZip());
+        assertEquals(null, res.refund.getToState());
+        assertEquals(null, res.refund.getToCity());
+        assertEquals(null, res.refund.getToStreet());
+        assertEquals(null, res.refund.getAmount());
+        assertEquals(null, res.refund.getShipping());
+        assertEquals(null, res.refund.getSalesTax());
+        assertEquals(Collections.emptyList(), res.refund.getLineItems());
+    }
+
+    public void testDeleteRefundAsync() throws TaxjarException {
         MockInterceptor interceptor = new MockInterceptor("refunds/delete.json");
         client = new TaxjarMock("TEST", interceptor);
 
@@ -387,6 +491,7 @@ public class RefundTest extends TestCase {
                 assertEquals("321", res.refund.getTransactionId());
                 assertEquals((Integer) 10649, res.refund.getUserId());
                 assertEquals(null, res.refund.getTransactionDate());
+                assertEquals("api", res.refund.getProvider());
                 assertEquals(null, res.refund.getToCountry());
                 assertEquals(null, res.refund.getToZip());
                 assertEquals(null, res.refund.getToState());
@@ -401,6 +506,37 @@ public class RefundTest extends TestCase {
             @Override
             public void onError(TaxjarException error)
             {
+            }
+        });
+    }
+
+    public void testDeleteRefundAsyncWithParams() throws TaxjarException {
+        MockInterceptor interceptor = new MockInterceptor("refunds/delete.json");
+        client = new TaxjarMock("TEST", interceptor);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("provider", "api");
+
+        client.deleteRefund("321", params, new Listener<RefundResponse>() {
+            @Override
+            public void onSuccess(RefundResponse res) {
+                assertEquals("321", res.refund.getTransactionId());
+                assertEquals((Integer) 10649, res.refund.getUserId());
+                assertEquals(null, res.refund.getTransactionDate());
+                assertEquals("api", res.refund.getProvider());
+                assertEquals(null, res.refund.getToCountry());
+                assertEquals(null, res.refund.getToZip());
+                assertEquals(null, res.refund.getToState());
+                assertEquals(null, res.refund.getToCity());
+                assertEquals(null, res.refund.getToStreet());
+                assertEquals(null, res.refund.getAmount());
+                assertEquals(null, res.refund.getShipping());
+                assertEquals(null, res.refund.getSalesTax());
+                assertEquals(Collections.emptyList(), res.refund.getLineItems());
+            }
+
+            @Override
+            public void onError(TaxjarException error) {
             }
         });
     }

--- a/src/test/resources/com/taxjar/fixtures/orders/delete.json
+++ b/src/test/resources/com/taxjar/fixtures/orders/delete.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": null,
     "transaction_reference_id": null,
+    "provider": "api",
     "from_country": null,
     "from_zip": null,
     "from_state": null,

--- a/src/test/resources/com/taxjar/fixtures/orders/show.json
+++ b/src/test/resources/com/taxjar/fixtures/orders/show.json
@@ -3,6 +3,7 @@
     "transaction_id": "123",
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
+    "provider": "api",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",

--- a/src/test/resources/com/taxjar/fixtures/refunds/delete.json
+++ b/src/test/resources/com/taxjar/fixtures/refunds/delete.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": null,
     "transaction_reference_id": null,
+    "provider": "api",
     "from_country": null,
     "from_zip": null,
     "from_state": null,

--- a/src/test/resources/com/taxjar/fixtures/refunds/show.json
+++ b/src/test/resources/com/taxjar/fixtures/refunds/show.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
     "transaction_reference_id": "123",
+    "provider": "api",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",


### PR DESCRIPTION
This PR implements the new `provider` param, which currently adds marketplace exemption support for Amazon, eBay, Etsy, and Walmart transactions. `provider` defaults to `api`.

The `provider` param will be supported in methods:

- `listOrders`
- `showOrder`
- `createOrder`
- `deleteOrder`
- `listRefunds`
- `showRefund`
- `createRefund`
- `deleteRefund`