### PR TITLE
Add support for order-level exemptions via `exemption_type` param

### DIFF
--- a/src/main/java/com/taxjar/model/taxes/Tax.java
+++ b/src/main/java/com/taxjar/model/taxes/Tax.java
@@ -27,6 +27,9 @@ public class Tax {
     @SerializedName("tax_source")
     String taxSource;
 
+    @SerializedName("exemption_type")
+    String exemptionType;
+
     // ---
 
     @SerializedName("jurisdictions")
@@ -67,7 +70,13 @@ public class Tax {
         return taxSource;
     }
 
-    public Jurisdictions getJurisdictions() { return jurisdictions; }
+    public String getExemptionType() {
+        return exemptionType;
+    }
+
+    public Jurisdictions getJurisdictions() {
+        return jurisdictions;
+    }
 
     public Breakdown getBreakdown() {
         return breakdown;

--- a/src/main/java/com/taxjar/model/transactions/Order.java
+++ b/src/main/java/com/taxjar/model/transactions/Order.java
@@ -52,6 +52,9 @@ public class Order {
     @SerializedName("sales_tax")
     Float salesTax;
 
+    @SerializedName("exemption_type")
+    String exemptionType;
+
     @SerializedName("line_items")
     List<LineItem> lineItems;
 
@@ -113,6 +116,10 @@ public class Order {
 
     public Float getSalesTax() {
         return salesTax;
+    }
+
+    public String getExemptionType() {
+        return exemptionType;
     }
 
     public Integer getUserId() {

--- a/src/main/java/com/taxjar/model/transactions/Refund.java
+++ b/src/main/java/com/taxjar/model/transactions/Refund.java
@@ -56,6 +56,9 @@ public class Refund {
     @SerializedName("sales_tax")
     Float salesTax;
 
+    @SerializedName("exemption_type")
+    String exemptionType;
+
     @SerializedName("line_items")
     List<LineItem> lineItems;
 
@@ -125,6 +128,10 @@ public class Refund {
 
     public Float getSalesTax() {
         return salesTax;
+    }
+
+    public String getExemptionType() {
+        return exemptionType;
     }
 
     public List<LineItem> getLineItems() {

--- a/src/test/java/com/taxjar/functional/OrderTest.java
+++ b/src/test/java/com/taxjar/functional/OrderTest.java
@@ -85,6 +85,7 @@ public class OrderTest extends TestCase {
         assertEquals("123", res.order.getTransactionId());
         assertEquals((Integer) 10649, res.order.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+        assertEquals("non_exempt", res.order.getExemptionType());
         assertEquals("US", res.order.getToCountry());
         assertEquals("90002", res.order.getToZip());
         assertEquals("CA", res.order.getToState());
@@ -114,6 +115,7 @@ public class OrderTest extends TestCase {
                 assertEquals("123", res.order.getTransactionId());
                 assertEquals((Integer) 10649, res.order.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+                assertEquals("non_exempt", res.order.getExemptionType());
                 assertEquals("US", res.order.getToCountry());
                 assertEquals("90002", res.order.getToZip());
                 assertEquals("CA", res.order.getToState());
@@ -146,6 +148,7 @@ public class OrderTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "123");
         params.put("transaction_date", "2015/05/04");
+        params.put("exemption_type", "non_exempt");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -169,6 +172,7 @@ public class OrderTest extends TestCase {
         assertEquals("123", res.order.getTransactionId());
         assertEquals((Integer) 10649, res.order.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+        assertEquals("non_exempt", res.order.getExemptionType());
         assertEquals("US", res.order.getToCountry());
         assertEquals("90002", res.order.getToZip());
         assertEquals("CA", res.order.getToState());
@@ -194,6 +198,7 @@ public class OrderTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "123");
         params.put("transaction_date", "2015/05/04");
+        params.put("exemption_type", "non_exempt");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -220,6 +225,7 @@ public class OrderTest extends TestCase {
                 assertEquals("123", res.order.getTransactionId());
                 assertEquals((Integer) 10649, res.order.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+                assertEquals("non_exempt", res.order.getExemptionType());
                 assertEquals("US", res.order.getToCountry());
                 assertEquals("90002", res.order.getToZip());
                 assertEquals("CA", res.order.getToState());
@@ -252,6 +258,7 @@ public class OrderTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "123");
         params.put("transaction_date", "2015/05/04");
+        params.put("exemption_type", "non_exempt");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -275,6 +282,7 @@ public class OrderTest extends TestCase {
         assertEquals("123", res.order.getTransactionId());
         assertEquals((Integer) 10649, res.order.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+        assertEquals("non_exempt", res.order.getExemptionType());
         assertEquals("US", res.order.getToCountry());
         assertEquals("90002", res.order.getToZip());
         assertEquals("CA", res.order.getToState());
@@ -300,6 +308,7 @@ public class OrderTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "123");
         params.put("transaction_date", "2015/05/04");
+        params.put("exemption_type", "non_exempt");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -326,6 +335,7 @@ public class OrderTest extends TestCase {
                 assertEquals("123", res.order.getTransactionId());
                 assertEquals((Integer) 10649, res.order.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.order.getTransactionDate());
+                assertEquals("non_exempt", res.order.getExemptionType());
                 assertEquals("US", res.order.getToCountry());
                 assertEquals("90002", res.order.getToZip());
                 assertEquals("CA", res.order.getToState());
@@ -359,6 +369,7 @@ public class OrderTest extends TestCase {
         assertEquals("123", res.order.getTransactionId());
         assertEquals((Integer) 10649, res.order.getUserId());
         assertEquals(null, res.order.getTransactionDate());
+        assertEquals(null, res.order.getExemptionType());
         assertEquals(null, res.order.getToCountry());
         assertEquals(null, res.order.getToZip());
         assertEquals(null, res.order.getToState());
@@ -381,6 +392,7 @@ public class OrderTest extends TestCase {
                 assertEquals("123", res.order.getTransactionId());
                 assertEquals((Integer) 10649, res.order.getUserId());
                 assertEquals(null, res.order.getTransactionDate());
+                assertEquals(null, res.order.getExemptionType());
                 assertEquals(null, res.order.getToCountry());
                 assertEquals(null, res.order.getToZip());
                 assertEquals(null, res.order.getToState());

--- a/src/test/java/com/taxjar/functional/RefundTest.java
+++ b/src/test/java/com/taxjar/functional/RefundTest.java
@@ -86,6 +86,7 @@ public class RefundTest extends TestCase {
         assertEquals((Integer) 10649, res.refund.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
         assertEquals("123", res.refund.getTransactionReferenceId());
+        assertEquals("non_exempt", res.refund.getExemptionType());
         assertEquals("US", res.refund.getToCountry());
         assertEquals("90002", res.refund.getToZip());
         assertEquals("CA", res.refund.getToState());
@@ -116,6 +117,7 @@ public class RefundTest extends TestCase {
                 assertEquals((Integer) 10649, res.refund.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
                 assertEquals("123", res.refund.getTransactionReferenceId());
+                assertEquals("non_exempt", res.refund.getExemptionType());
                 assertEquals("US", res.refund.getToCountry());
                 assertEquals("90002", res.refund.getToZip());
                 assertEquals("CA", res.refund.getToState());
@@ -148,6 +150,7 @@ public class RefundTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "321");
         params.put("transaction_date", "2015/05/04");
+        params.put("exemption_type", "non_exempt");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -172,6 +175,7 @@ public class RefundTest extends TestCase {
         assertEquals((Integer) 10649, res.refund.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
         assertEquals("123", res.refund.getTransactionReferenceId());
+        assertEquals("non_exempt", res.refund.getExemptionType());
         assertEquals("US", res.refund.getToCountry());
         assertEquals("90002", res.refund.getToZip());
         assertEquals("CA", res.refund.getToState());
@@ -197,6 +201,7 @@ public class RefundTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "321");
         params.put("transaction_date", "2015/05/04");
+        params.put("exemption_type", "non_exempt");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -224,6 +229,7 @@ public class RefundTest extends TestCase {
                 assertEquals((Integer) 10649, res.refund.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
                 assertEquals("123", res.refund.getTransactionReferenceId());
+                assertEquals("non_exempt", res.refund.getExemptionType());
                 assertEquals("US", res.refund.getToCountry());
                 assertEquals("90002", res.refund.getToZip());
                 assertEquals("CA", res.refund.getToState());
@@ -256,6 +262,7 @@ public class RefundTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "321");
         params.put("transaction_date", "2015/05/04");
+        params.put("exemption_type", "non_exempt");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -280,6 +287,7 @@ public class RefundTest extends TestCase {
         assertEquals((Integer) 10649, res.refund.getUserId());
         assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
         assertEquals("123", res.refund.getTransactionReferenceId());
+        assertEquals("non_exempt", res.refund.getExemptionType());
         assertEquals("US", res.refund.getToCountry());
         assertEquals("90002", res.refund.getToZip());
         assertEquals("CA", res.refund.getToState());
@@ -305,6 +313,7 @@ public class RefundTest extends TestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("transaction_id", "321");
         params.put("transaction_date", "2015/05/04");
+        params.put("exemption_type", "non_exempt");
         params.put("to_country", "US");
         params.put("to_zip", "90002");
         params.put("to_city", "Los Angeles");
@@ -332,6 +341,7 @@ public class RefundTest extends TestCase {
                 assertEquals((Integer) 10649, res.refund.getUserId());
                 assertEquals("2015-05-14T00:00:00Z", res.refund.getTransactionDate());
                 assertEquals("123", res.refund.getTransactionReferenceId());
+                assertEquals("non_exempt", res.refund.getExemptionType());
                 assertEquals("US", res.refund.getToCountry());
                 assertEquals("90002", res.refund.getToZip());
                 assertEquals("CA", res.refund.getToState());
@@ -365,6 +375,7 @@ public class RefundTest extends TestCase {
         assertEquals("321", res.refund.getTransactionId());
         assertEquals((Integer) 10649, res.refund.getUserId());
         assertEquals(null, res.refund.getTransactionDate());
+        assertEquals(null, res.refund.getExemptionType());
         assertEquals(null, res.refund.getToCountry());
         assertEquals(null, res.refund.getToZip());
         assertEquals(null, res.refund.getToState());
@@ -387,6 +398,7 @@ public class RefundTest extends TestCase {
                 assertEquals("321", res.refund.getTransactionId());
                 assertEquals((Integer) 10649, res.refund.getUserId());
                 assertEquals(null, res.refund.getTransactionDate());
+                assertEquals(null, res.refund.getExemptionType());
                 assertEquals(null, res.refund.getToCountry());
                 assertEquals(null, res.refund.getToZip());
                 assertEquals(null, res.refund.getToState());

--- a/src/test/java/com/taxjar/functional/TaxTest.java
+++ b/src/test/java/com/taxjar/functional/TaxTest.java
@@ -31,6 +31,7 @@ public class TaxTest extends TestCase {
         params.put("to_street", "1335 E 103rd St");
         params.put("amount", 15);
         params.put("shipping", 1.5);
+        params.put("exemption_type", "non_exempt");
 
         List<Map> nexusAddresses = new ArrayList();
         Map<String, Object> nexusAddress = new HashMap<>();
@@ -62,6 +63,7 @@ public class TaxTest extends TestCase {
         assertEquals((Boolean) true, res.tax.getHasNexus());
         assertEquals((Boolean) true, res.tax.getFreightTaxable());
         assertEquals("destination", res.tax.getTaxSource());
+        assertEquals("non_exempt", res.tax.getExemptionType());
         assertEquals("US", res.tax.getJurisdictions().getCountry());
         assertEquals("CA", res.tax.getJurisdictions().getState());
         assertEquals("LOS ANGELES", res.tax.getJurisdictions().getCounty());
@@ -130,6 +132,7 @@ public class TaxTest extends TestCase {
         params.put("to_street", "1335 E 103rd St");
         params.put("amount", 15);
         params.put("shipping", 1.5);
+        params.put("exemption_type", "non_exempt");
 
         List<Map> nexusAddresses = new ArrayList();
         Map<String, Object> nexusAddress = new HashMap<>();
@@ -164,6 +167,7 @@ public class TaxTest extends TestCase {
                 assertEquals((Boolean) true, res.tax.getHasNexus());
                 assertEquals((Boolean) true, res.tax.getFreightTaxable());
                 assertEquals("destination", res.tax.getTaxSource());
+                assertEquals("non_exempt", res.tax.getExemptionType());
                 assertEquals("US", res.tax.getJurisdictions().getCountry());
                 assertEquals("CA", res.tax.getJurisdictions().getState());
                 assertEquals("LOS ANGELES", res.tax.getJurisdictions().getCounty());
@@ -239,6 +243,7 @@ public class TaxTest extends TestCase {
         params.put("to_street", "301 Front St W");
         params.put("amount", 15);
         params.put("shipping", 1.5);
+        params.put("exemption_type", "non_exempt");
 
         List<Map> nexusAddresses = new ArrayList();
         Map<String, Object> nexusAddress = new HashMap<>();
@@ -269,6 +274,7 @@ public class TaxTest extends TestCase {
         assertEquals((Boolean) true, res.tax.getHasNexus());
         assertEquals((Boolean) true, res.tax.getFreightTaxable());
         assertEquals("destination", res.tax.getTaxSource());
+        assertEquals("non_exempt", res.tax.getExemptionType());
         assertEquals("CA", res.tax.getJurisdictions().getCountry());
         assertEquals("ON", res.tax.getJurisdictions().getState());
         assertEquals(26.95f, res.tax.getBreakdown().getTaxableAmount());
@@ -320,6 +326,7 @@ public class TaxTest extends TestCase {
         params.put("to_zip", "00150");
         params.put("amount", 16.95);
         params.put("shipping", 10);
+        params.put("exemption_type", "non_exempt");
 
         List<Map> lineItems = new ArrayList();
         Map<String, Object> lineItem = new HashMap<>();
@@ -339,6 +346,7 @@ public class TaxTest extends TestCase {
         assertEquals((Boolean) true, res.tax.getHasNexus());
         assertEquals((Boolean) true, res.tax.getFreightTaxable());
         assertEquals("destination", res.tax.getTaxSource());
+        assertEquals("non_exempt", res.tax.getExemptionType());
         assertEquals("FI", res.tax.getJurisdictions().getCountry());
         assertEquals(26.95f, res.tax.getBreakdown().getTaxableAmount());
         assertEquals(6.47f, res.tax.getBreakdown().getTaxCollectable());

--- a/src/test/resources/com/taxjar/fixtures/orders/delete.json
+++ b/src/test/resources/com/taxjar/fixtures/orders/delete.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": null,
     "transaction_reference_id": null,
+    "exemption_type": null,
     "from_country": null,
     "from_zip": null,
     "from_state": null,

--- a/src/test/resources/com/taxjar/fixtures/orders/show.json
+++ b/src/test/resources/com/taxjar/fixtures/orders/show.json
@@ -3,6 +3,7 @@
     "transaction_id": "123",
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
+    "exemption_type": "non_exempt",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",

--- a/src/test/resources/com/taxjar/fixtures/refunds/delete.json
+++ b/src/test/resources/com/taxjar/fixtures/refunds/delete.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": null,
     "transaction_reference_id": null,
+    "exemption_type": null,
     "from_country": null,
     "from_zip": null,
     "from_state": null,

--- a/src/test/resources/com/taxjar/fixtures/refunds/show.json
+++ b/src/test/resources/com/taxjar/fixtures/refunds/show.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
     "transaction_reference_id": "123",
+    "exemption_type": "non_exempt",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",

--- a/src/test/resources/com/taxjar/fixtures/taxes.json
+++ b/src/test/resources/com/taxjar/fixtures/taxes.json
@@ -8,6 +8,7 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "exemption_type": "non_exempt",
     "jurisdictions": {
       "country": "US",
       "state": "CA",

--- a/src/test/resources/com/taxjar/fixtures/taxes_ca.json
+++ b/src/test/resources/com/taxjar/fixtures/taxes_ca.json
@@ -8,6 +8,7 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "exemption_type": "non_exempt",
     "jurisdictions": {
       "country": "CA",
       "state": "ON"

--- a/src/test/resources/com/taxjar/fixtures/taxes_eu.json
+++ b/src/test/resources/com/taxjar/fixtures/taxes_eu.json
@@ -8,6 +8,7 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "exemption_type": "non_exempt",
     "jurisdictions": {
       "country": "FI"
     },


### PR DESCRIPTION
This change introduces an optional `exemption_type` parameter for:

- taxForOrder
- createOrder
- updateOrder
- createRefund
- updateRefund

The allowable values are: `government`, `wholesale`, `other`, and `non_exempt`.

With the exception of `non_exempt`, a request with one of these values indicates a transaction that is fully-exempt at the order level.

When also using the existing optional `customer_id` parameter, an `exemption_type` value of `non_exempt` specifies that a transaction belonging to an otherwise exempt customer be processed as taxable.

With the exception of `non_exempt`, when usage of the `customer_id` param qualifies the transaction as exempt, the customer's exemption type would be applied, rather than the `exemption_type` submitted in the request.