### PR TITLE
Add more information to custom user agent string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
       <version>3.12.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>com.jcabi</groupId>
+        <artifactId>jcabi-matchers</artifactId>
+        <version>1.4</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -30,7 +30,9 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 import java.io.IOException;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class Taxjar {
@@ -71,7 +73,7 @@ public class Taxjar {
             public okhttp3.Response intercept(Chain chain) throws IOException {
                 Request newRequest = chain.request().newBuilder()
                         .addHeader("Authorization", "Bearer " + apiToken)
-                        .addHeader("User-Agent", "TaxJarJava/" + VERSION)
+                        .addHeader("User-Agent", getUserAgent())
                         .build();
                 return chain.proceed(newRequest);
             }
@@ -92,6 +94,18 @@ public class Taxjar {
                 .build();
 
         apiService = retrofit.create(Endpoints.class);
+    }
+
+    private static String getUserAgent() {
+        String[] propertyNames = {"os.name", "os.version", "os.arch", "java.version", "java.vendor"};
+        Set<String> properties = new LinkedHashSet<String>();
+
+        for (String property : propertyNames)
+            properties.add(System.getProperty(property));
+
+        properties.add(VERSION);
+
+        return String.format("TaxJar/Java (%s %s; %s; java %s; %s) taxjar-java/%s", properties.toArray());
     }
 
     public String getApiConfig(String key) {

--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -102,8 +102,9 @@ public class Taxjar {
         String[] propertyNames = {"os.name", "os.version", "os.arch", "java.version", "java.vendor"};
         Set<String> properties = new LinkedHashSet<String>();
 
-        for (String property : propertyNames)
+        for (String property : propertyNames) {
             properties.add(System.getProperty(property));
+        }
 
         properties.add(VERSION);
 

--- a/src/test/java/com/taxjar/config/ConfigTest.java
+++ b/src/test/java/com/taxjar/config/ConfigTest.java
@@ -1,8 +1,14 @@
 package com.taxjar.config;
 
+import com.jcabi.matchers.RegexMatchers;
 import com.taxjar.Taxjar;
+
 import junit.framework.TestCase;
 
+import static org.junit.Assert.assertThat;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -42,5 +48,13 @@ public class ConfigTest extends TestCase {
 
         client.setApiConfig("timeout", 60 * 1000);
         assertEquals(client.getApiConfig("timeout"), "60000");
+    }
+
+    public void testGetUserAgent() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        Method getUserAgent = Taxjar.class.getDeclaredMethod("getUserAgent");
+        getUserAgent.setAccessible(true);
+        String userAgent = (String) getUserAgent.invoke(null);
+
+        assertThat(userAgent, RegexMatchers.matchesPattern("^TaxJar/Java \\(.+\\) taxjar-java/\\d+\\.\\d+\\.\\d+$"));
     }
 }


### PR DESCRIPTION
To help debug technical issues, it's necessary to collect additional information about a user's server.

For that purpose, this PR adds a custom user agent string to each request, which includes the following information:

- Operating system
- Java version
- Java vendor
- Version of taxjar-java currently being used

Example UA string:
<img width="618" alt="Screen Shot 2020-03-24 at 6 56 50 PM" src="https://user-images.githubusercontent.com/26824724/77494097-189aa780-6e02-11ea-9cb9-2b2b92d686d6.png">
