### PR TITLE
INT-574 Require TLS1.2+ for security reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.0.0] - 2020-04-30
+- Update retrofit dependency to version `2.8.1`; note: this change drops support for TLS 1.1 and TLS 1.0
+
 ## [3.3.0] - 2020-03-31
 - Add information to custom user agent for debugging and informational purposes
 - Fix issue with retrofit dependency not encoding path parameters properly
@@ -41,7 +44,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0] - 2017-07-12
 - Initial release
 
-[Unreleased]: https://github.com/taxjar/taxjar-java/compare/v3.3.0...HEAD
+[Unreleased]: https://github.com/taxjar/taxjar-java/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/taxjar/taxjar-java/compare/v3.3.0...v4.0.0
 [3.3.0]: https://github.com/taxjar/taxjar-java/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/taxjar/taxjar-java/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/taxjar/taxjar-java/compare/v3.0.0...v3.1.0

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add the following dependency to your project's `pom.xml` file:
 <dependency>
     <groupId>com.taxjar</groupId>
     <artifactId>taxjar-java</artifactId>
-    <version>3.3.0</version>
+    <version>4.0.0</version>
 </dependency>
 ```
 
@@ -41,7 +41,7 @@ Add the following dependency to your project's `pom.xml` file:
 Add the following dependency to your project's build file:
 
 ```
-compile "com.taxjar:taxjar-java:3.3.0"
+compile "com.taxjar:taxjar-java:4.0.0"
 ```
 
 ### Manual Installation

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>converter-gson</artifactId>
-      <version>2.5.0</version>
+      <version>2.8.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>retrofit</artifactId>
-      <version>2.5.0</version>
+      <version>2.8.1</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.taxjar</groupId>
   <artifactId>taxjar-java</artifactId>
-  <version>3.3.0</version>
+  <version>4.0.0</version>
   <packaging>jar</packaging>
 
   <name>taxjar-java</name>

--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -41,7 +41,7 @@ public class Taxjar {
     public static final String DEFAULT_API_URL = "https://api.taxjar.com";
     public static final String SANDBOX_API_URL = "https://api.sandbox.taxjar.com";
     public static final String API_VERSION = "v2";
-    public static final String VERSION = "3.3.0";
+    public static final String VERSION = "4.0.0";
     protected Endpoints apiService;
     protected String apiUrl;
     protected String apiToken;


### PR DESCRIPTION
To ensure customer data continues to be secure at TaxJar, we'll be requiring [TLS 1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.2) for all requests to the [TaxJar Sales Tax API](https://developers.taxjar.com/api/reference/) starting on July 1, 2020.

This PR updates the `retrofit` dependency to version `2.8.1`, which drops support for TLS 1.1 and TLS 1.0, thus requiring TLS 1.2+. For more information on this transition, see: https://developers.taxjar.com/api/guides/#security