### PR TITLE
API Version / Custom Header Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,34 @@ public class SummarizedRatesExample {
 
 You can pass additional options using `setApiConfig` or when instantiating the client for the following:
 
+### API Version / Headers
+
+Pass an API version with `x-api-version` or pass additional request headers:
+
+```java
+import com.taxjar.Taxjar;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomHeaderExample {
+
+    public static void main(String[] args) {
+        // Custom header when instantiating the client
+        Map<String, Object> params = new HashMap<>();
+        Map<String, String> headers = new HashMap<>();
+        
+        headers.put("x-api-version", "2020-08-07");
+        params.put("headers", headers);
+
+        Taxjar client = new Taxjar("YOUR API TOKEN", params);
+
+        // Custom header via `setApiConfig`
+        client.setApiConfig("headers", headers);
+    }
+
+}
+```
+
 ### Timeouts
 
 The default timeout is 30 seconds (specified in milliseconds).

--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -105,7 +105,7 @@ public class Taxjar {
         apiService = retrofit.create(Endpoints.class);
     }
 
-    private static String getUserAgent() {
+    protected static String getUserAgent() {
         String[] propertyNames = {"os.name", "os.version", "os.arch", "java.version", "java.vendor"};
         Set<String> properties = new LinkedHashSet<String>();
 

--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -45,6 +45,7 @@ public class Taxjar {
     protected Endpoints apiService;
     protected String apiUrl;
     protected String apiToken;
+    protected Map<String, String> headers;
     protected long timeout = 30000;
 
     public Taxjar(final String apiToken) {
@@ -73,11 +74,17 @@ public class Taxjar {
         OkHttpClient client = new OkHttpClient.Builder().addInterceptor(new Interceptor() {
             @Override
             public okhttp3.Response intercept(Chain chain) throws IOException {
-                Request newRequest = chain.request().newBuilder()
+                Request.Builder requestBuilder = chain.request().newBuilder()
                         .addHeader("Authorization", "Bearer " + apiToken)
-                        .addHeader("User-Agent", getUserAgent())
-                        .build();
-                return chain.proceed(newRequest);
+                        .addHeader("User-Agent", getUserAgent());
+
+                if (headers != null) {
+                    for (Map.Entry<String, String> header : headers.entrySet()) {
+                        requestBuilder.addHeader(header.getKey(), header.getValue());
+                    }
+                }
+
+                return chain.proceed(requestBuilder.build());
             }
         })
                 .connectTimeout(this.timeout, TimeUnit.MILLISECONDS)

--- a/src/main/java/com/taxjar/Taxjar.java
+++ b/src/main/java/com/taxjar/Taxjar.java
@@ -111,11 +111,11 @@ public class Taxjar {
         return String.format("TaxJar/Java (%s %s; %s; java %s; %s) taxjar-java/%s", properties.toArray());
     }
 
-    public String getApiConfig(String key) {
+    public Object getApiConfig(String key) {
         try {
-            return getClass().getDeclaredField(key).get(this).toString();
+            return getClass().getDeclaredField(key).get(this);
         } catch (NoSuchFieldException | IllegalAccessException ex) {
-            return "";
+            return null;
         }
     }
 

--- a/src/test/java/com/taxjar/TaxjarMock.java
+++ b/src/test/java/com/taxjar/TaxjarMock.java
@@ -34,15 +34,22 @@ public final class TaxjarMock extends Taxjar {
         final OkHttpClient client = new OkHttpClient.Builder().addInterceptor(new Interceptor() {
             @Override
             public okhttp3.Response intercept(Chain chain) throws IOException {
-                Request newRequest = chain.request().newBuilder()
+                Request.Builder requestBuilder = chain.request().newBuilder()
                         .addHeader("Authorization", "Bearer " + apiToken)
-                        .build();
-                return chain.proceed(newRequest);
+                        .addHeader("User-Agent", getUserAgent());
+
+                if (headers != null) {
+                    for (Map.Entry<String, String> header : headers.entrySet()) {
+                        requestBuilder.addHeader(header.getKey(), header.getValue());
+                    }
+                }
+
+                return chain.proceed(requestBuilder.build());
             }
         }).addInterceptor(interceptor)
-                .connectTimeout(timeout, TimeUnit.MILLISECONDS)
-                .writeTimeout(timeout, TimeUnit.MILLISECONDS)
-                .readTimeout(timeout, TimeUnit.MILLISECONDS)
+                .connectTimeout(this.timeout, TimeUnit.MILLISECONDS)
+                .writeTimeout(this.timeout, TimeUnit.MILLISECONDS)
+                .readTimeout(this.timeout, TimeUnit.MILLISECONDS)
                 .build();
 
         Gson gson = new GsonBuilder()
@@ -50,7 +57,7 @@ public final class TaxjarMock extends Taxjar {
                 .create();
 
         Retrofit retrofit = new Retrofit.Builder()
-                .baseUrl(DEFAULT_API_URL + "/" + API_VERSION + "/")
+                .baseUrl(this.apiUrl + "/" + API_VERSION + "/")
                 .addConverterFactory(GsonConverterFactory.create(gson))
                 .client(client)
                 .build();

--- a/src/test/java/com/taxjar/config/ConfigTest.java
+++ b/src/test/java/com/taxjar/config/ConfigTest.java
@@ -25,13 +25,19 @@ public class ConfigTest extends TestCase {
         params.put("apiUrl", Taxjar.SANDBOX_API_URL);
         params.put("timeout", 60 * 1000);
 
+        Map<String, String> headers = new HashMap<>();
+        headers.put("x-api-version", "2020-08-07");
+        params.put("headers", headers);
+
         client = new Taxjar("TEST", params);
         assertEquals(client.getApiConfig("apiUrl"), Taxjar.SANDBOX_API_URL);
         assertEquals((long) client.getApiConfig("timeout"), 60000);
+        assertEquals(client.getApiConfig("headers"), headers);
 
         client2 = new Taxjar("TEST2");
         assertEquals(client.getApiConfig("apiToken"), "TEST");
         assertEquals(client2.getApiConfig("apiToken"), "TEST2");
+        assertEquals(client2.getApiConfig("headers"), null);
     }
 
     public void testGetApiConfig() {
@@ -47,6 +53,12 @@ public class ConfigTest extends TestCase {
 
         client.setApiConfig("timeout", 60 * 1000);
         assertEquals((long) client.getApiConfig("timeout"), 60000);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("x-api-version", "2020-08-07");
+
+        client.setApiConfig("headers", headers);
+        assertEquals(client.getApiConfig("headers"), headers);
     }
 
     public void testGetUserAgent() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {

--- a/src/test/java/com/taxjar/config/ConfigTest.java
+++ b/src/test/java/com/taxjar/config/ConfigTest.java
@@ -27,7 +27,7 @@ public class ConfigTest extends TestCase {
 
         client = new Taxjar("TEST", params);
         assertEquals(client.getApiConfig("apiUrl"), Taxjar.SANDBOX_API_URL);
-        assertEquals(client.getApiConfig("timeout"), "60000");
+        assertEquals((long) client.getApiConfig("timeout"), 60000);
 
         client2 = new Taxjar("TEST2");
         assertEquals(client.getApiConfig("apiToken"), "TEST");
@@ -35,8 +35,7 @@ public class ConfigTest extends TestCase {
     }
 
     public void testGetApiConfig() {
-        String apiUrl = client.getApiConfig("apiUrl");
-        assertEquals(apiUrl, Taxjar.DEFAULT_API_URL);
+        assertEquals(client.getApiConfig("apiUrl"), Taxjar.DEFAULT_API_URL);
     }
 
     public void testSetApiConfig() {
@@ -47,7 +46,7 @@ public class ConfigTest extends TestCase {
         assertEquals(client.getApiConfig("apiToken"), "foobar");
 
         client.setApiConfig("timeout", 60 * 1000);
-        assertEquals(client.getApiConfig("timeout"), "60000");
+        assertEquals((long) client.getApiConfig("timeout"), 60000);
     }
 
     public void testGetUserAgent() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {


### PR DESCRIPTION
This PR adds support for passing custom request headers such as `x-api-version` and resolves #30:

```java
import com.taxjar.Taxjar;
import java.util.HashMap;
import java.util.Map;

public class CustomHeaderExample {
    public static void main(String[] args) {
        // Custom header when instantiating the client
        Map<String, Object> params = new HashMap<>();
        Map<String, String> headers = new HashMap<>();
        
        headers.put("x-api-version", "2020-08-07");
        params.put("headers", headers);
        Taxjar client = new Taxjar("YOUR API TOKEN", params);
        // Custom header via `setApiConfig`
        client.setApiConfig("headers", headers);
    }
}
```

Return type for `getApiConfig` has been changed from `String` to `Object` to support different types set using `setApiConfig` beyond `String`. This change may affect implementations using `getApiConfig`, so we should bump the major version to `v5.0.0` just in case.

The specs below verify the behavior of passing custom headers on client instantiation and `setApiConfig`. We do not have full test coverage for verifying request headers through the Retrofit interceptor. I created several scratch files with the API client update and verified the `x-api-version` header was passed properly.