### PR TITLE
ISSUE-2944 handles missing error/detail/status keys from response json

### DIFF
--- a/src/main/java/com/taxjar/exception/TaxjarException.java
+++ b/src/main/java/com/taxjar/exception/TaxjarException.java
@@ -1,6 +1,7 @@
 package com.taxjar.exception;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 
@@ -25,7 +26,14 @@ public class TaxjarException extends Exception {
 
         try {
             JsonObject json = gson.fromJson(errorMessage, JsonObject.class);
-            return json.get("error").getAsString() + " - " + json.get("detail").getAsString();
+            JsonElement error = json.get("error");
+            JsonElement detail = json.get("detail");
+
+            if (error != null && detail != null) {
+                return error.getAsString() + " - " + detail.getAsString();
+            } else {
+                return errorMessage;
+            }
         } catch (JsonSyntaxException e) {
             return errorMessage;
         }
@@ -36,7 +44,13 @@ public class TaxjarException extends Exception {
 
         try {
             JsonObject json = gson.fromJson(errorMessage, JsonObject.class);
-            return json.get("status").getAsInt();
+            JsonElement status = json.get("status");
+
+            if (status != null) {
+                return status.getAsInt();
+            } else {
+                return 0;
+            }
         } catch (JsonSyntaxException e) {
             return 0;
         }

--- a/src/test/java/com/taxjar/exception/ExceptionTest.java
+++ b/src/test/java/com/taxjar/exception/ExceptionTest.java
@@ -115,4 +115,40 @@ public class ExceptionTest extends TestCase {
 
         server.shutdown();
     }
+
+    public void testJsonMissingError() {
+        String json = "{\"detail\":\"\", \"status\":400}";
+        TaxjarException e = new TaxjarException(json);
+
+        assertTrue(e instanceof TaxjarException);
+        assertEquals(json, e.getMessage());
+        assertEquals((Integer) 400, e.getStatusCode());
+    }
+
+    public void testJsonMissingDetail() {
+        String json = "{\"error\":\"\", \"status\":400}";
+        TaxjarException e = new TaxjarException(json);
+
+        assertTrue(e instanceof TaxjarException);
+        assertEquals(json, e.getMessage());
+        assertEquals((Integer) 400, e.getStatusCode());
+    }
+
+    public void testJsonMissingStatus() {
+        String json = "{\"error\":\"\", \"detail\":\"\"}";
+        TaxjarException e = new TaxjarException(json);
+
+        assertTrue(e instanceof TaxjarException);
+        assertEquals(" - ", e.getMessage());
+        assertEquals((Integer) 0, e.getStatusCode());
+    }
+
+    public void testEmptyJson() {
+        String json = "{}";
+        TaxjarException e = new TaxjarException(json);
+
+        assertTrue(e instanceof TaxjarException);
+        assertEquals(json, e.getMessage());
+        assertEquals((Integer) 0, e.getStatusCode());
+    }
 }


### PR DESCRIPTION
When a JSON response is missing `error`, `detail`, or `status` keys, `TaxjarException` is crashing.

This change will check that fetching those keys aren't null, before converting to a string or integer.

One thing to note, if `error` key exists and `detail` does not (or vice-versa), this returns the whole response as a string. I don't believe there's any instance of returning one w/o the other, but if preferred I can update to return the value of whichever key exists. This is the same behavior when there's a `JsonSyntaxException`.