### PR TITLE
Patch vulnerability in Gson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
       <version>2.8.1</version>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.9</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>


### PR DESCRIPTION
This PR patches a vulnerability introduced by the transitive dependency of converter-gson by explicitly defining a dependency on a secure version of gson.