### PR TITLE
Fix Null Request Body in Exception and handle 500 Errors

### DIFF
--- a/src/main/java/com/taxjar/exception/TaxjarException.java
+++ b/src/main/java/com/taxjar/exception/TaxjarException.java
@@ -8,6 +8,11 @@ import com.google.gson.JsonSyntaxException;
 public class TaxjarException extends Exception {
     private Integer statusCode;
 
+    public TaxjarException(String errorMessage, int statusCode) {
+        super(parseMessage(errorMessage), null);
+        this.statusCode = parseStatusCode(errorMessage, statusCode);
+    }
+
     public TaxjarException(String errorMessage) {
         this(errorMessage, null);
     }
@@ -24,6 +29,8 @@ public class TaxjarException extends Exception {
     private static String parseMessage(String errorMessage) {
         Gson gson = new Gson();
 
+        if (errorMessage == null || errorMessage.equals("")) return "";
+
         try {
             JsonObject json = gson.fromJson(errorMessage, JsonObject.class);
             JsonElement error = json.get("error");
@@ -39,8 +46,18 @@ public class TaxjarException extends Exception {
         }
     }
 
+    private static Integer parseStatusCode(String errorMessage, int statusCode) {
+        if (errorMessage == null || errorMessage.equals("")) {
+            return statusCode;
+        } else {
+            return parseStatusCode(errorMessage);
+        }
+    }
+
     private static Integer parseStatusCode(String errorMessage) {
         Gson gson = new Gson();
+
+        if (errorMessage == null) return 0;
 
         try {
             JsonObject json = gson.fromJson(errorMessage, JsonObject.class);

--- a/src/main/java/com/taxjar/net/ApiRequest.java
+++ b/src/main/java/com/taxjar/net/ApiRequest.java
@@ -20,7 +20,7 @@ public class ApiRequest<T> {
             if (response.isSuccessful()) {
                 return response.body();
             } else {
-                throw new TaxjarException(response.errorBody().string());
+                throw new TaxjarException(response.errorBody().string(), response.code());
             }
         } catch (IOException e) {
             throw new ApiConnectionException(e.getMessage(), e);

--- a/src/test/java/com/taxjar/exception/ExceptionTest.java
+++ b/src/test/java/com/taxjar/exception/ExceptionTest.java
@@ -1,5 +1,7 @@
 package com.taxjar.exception;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.taxjar.MockInterceptor;
 import com.taxjar.Taxjar;
 import com.taxjar.TaxjarMock;
@@ -150,5 +152,37 @@ public class ExceptionTest extends TestCase {
         assertTrue(e instanceof TaxjarException);
         assertEquals(json, e.getMessage());
         assertEquals((Integer) 0, e.getStatusCode());
+    }
+
+    public void testNullErrorMessage() {
+        TaxjarException e = new TaxjarException(null);
+
+        assertEquals("", e.getMessage());
+        assertEquals((Integer) 0, e.getStatusCode());
+    }
+
+    public void test500Response() throws IOException {
+        TaxjarException e = null;
+        MockWebServer server = new MockWebServer();
+        MockResponse response = new MockResponse().setResponseCode(500);
+
+        server.enqueue(response);
+        server.start();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("apiUrl", "http://" + server.getHostName() + ":" + server.getPort());
+        params.put("timeout", 500);
+        Taxjar client = new Taxjar("TEST", params);
+
+        try {
+            CategoryResponse res = client.categories();
+        } catch (TaxjarException ex) {
+            e = ex;
+        }
+
+        assertEquals("", e.getMessage());
+        assertEquals((Integer) 500, e.getStatusCode());
+
+        server.shutdown();
     }
 }


### PR DESCRIPTION
This PR resolves the issue brought up in https://github.com/taxjar/taxjar-java/issues/35. When a request to the TaxJar API failed, a null pointer exception would be thrown. Additionally, for failed requests (500 errors) the error code was not properly being set on the exception since it was not present in the response body.